### PR TITLE
ROU-4049: Issue in number columns when not setting one of the bounds

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/NumberColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/NumberColumn.ts
@@ -123,6 +123,12 @@ namespace Providers.DataGrid.Wijmo.Column {
                               .decimals;
             }
 
+            if (this.editorConfig.minValue > this.editorConfig.maxValue) {
+                console.warn(
+                    `The Number Column ${this.config.binding}'s  MinValue parameter must have a smaller value than the MaxValue parameter to ensure their correct behaviour. Please review those parameters values.`
+                );
+            }
+
             this._setMaxValue();
             this._setMinValue();
             this._setEditorFormat(this.editorConfig.hasThousandSeparator);
@@ -149,10 +155,20 @@ namespace Providers.DataGrid.Wijmo.Column {
                     this.applyConfigs();
                     break;
                 case OSFramework.DataGrid.OSStructure.ColumnProperties.MinValue:
+                    if (propertyValue > this.editorConfig.maxValue) {
+                        console.warn(
+                            `The Number Column ${this.config.binding}'s  MinValue parameter must have a smaller value than the MaxValue parameter to ensure their correct behaviour. Please review those parameters values.`
+                        );
+                    }
                     this._setMinValue(propertyValue);
                     this.applyConfigs();
                     break;
                 case OSFramework.DataGrid.OSStructure.ColumnProperties.MaxValue:
+                    if (this.editorConfig.minValue > propertyValue) {
+                        console.warn(
+                            `The Number Column ${this.config.binding}'s  MinValue parameter must have a smaller value than the MaxValue parameter to ensure their correct behaviour. Please review those parameters values.`
+                        );
+                    }
                     this._setMaxValue(propertyValue);
                     this.applyConfigs();
                     break;


### PR DESCRIPTION
This PR is for add warning message for when NumberColumn's MaxValue is smaller than MinValue

[Sample page](url)

### What was happening
* When using a MinValue bigger than 0 and keep the MaxValue unset, the input value in the cell is being forced to the MinValue.
* It occurs because the MinValue and MaxValue default value are 0. 

### What was done
* Added a warning message to warn when the MinValue is bigger than the MaxValue.

### Test Steps
1. Add a Number Column
2. Set the MinValue and the MAxValue in a way that MinValue > MaxValue.
3. Check if the warning message appears on DevTools console.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

