### PR TITLE
ROU-4049-2: Issue in number columns when not setting one of the bounds

### DIFF
--- a/src/OSFramework/DataGrid/Configuration/Column/EditorConfigNumber.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/EditorConfigNumber.ts
@@ -35,13 +35,19 @@ namespace OSFramework.DataGrid.Configuration.Column {
                 format: this.format,
                 isRequired: this.required,
                 min:
-                    this.minValue < this.minPerDecPlaces
-                        ? this.minPerDecPlaces
-                        : this.minValue,
+                    // minPerDecPlaces defines the limit of the minValue,
+                    // so it takes precedence over minValue if minValue is smaller than minPerDecPlaces
+                    this.minValue !== undefined &&
+                    this.minValue > this.minPerDecPlaces
+                        ? this.minValue
+                        : this.minPerDecPlaces,
                 max:
-                    this.maxValue > this.maxPerDecPlaces
-                        ? this.maxPerDecPlaces
-                        : this.maxValue,
+                    // maxPerDecPlaces defines the limit of the maxValue,
+                    // so it takes precedence over maxValue if maxValue is bigger than maxPerDecPlaces
+                    this.maxValue !== undefined &&
+                    this.maxValue < this.maxPerDecPlaces
+                        ? this.maxValue
+                        : this.maxPerDecPlaces,
                 step: this.step
             };
 

--- a/src/OSFramework/DataGrid/Configuration/Column/EditorConfigNumber.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/EditorConfigNumber.ts
@@ -6,17 +6,17 @@ namespace OSFramework.DataGrid.Configuration.Column {
     export class EditorConfigNumber extends AbstractEditorConfig {
         public decimalPlaces: number;
         public hasThousandSeparator: boolean;
-        public maxValue?: number;
-        public minValue?: number;
         public maxPerDecPlaces: number;
+        public maxValue?: number;
         public minPerDecPlaces: number;
+        public minValue?: number;
         public step: number;
 
         // eslint-disable-next-line
         constructor(
             config:
                 | DataGrid.Types.INumberColumnExtraConfigs
-                | OSFramework.DataGrid.Types.ICurrencyColumnExtraConfigs
+                | DataGrid.Types.ICurrencyColumnExtraConfigs
         ) {
             super(config);
 

--- a/src/OSFramework/DataGrid/Configuration/Column/EditorConfigNumber.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/EditorConfigNumber.ts
@@ -8,10 +8,16 @@ namespace OSFramework.DataGrid.Configuration.Column {
         public hasThousandSeparator: boolean;
         public maxValue?: number;
         public minValue?: number;
+        public maxPerDecPlaces: number;
+        public minPerDecPlaces: number;
         public step: number;
 
         // eslint-disable-next-line
-        constructor(config: DataGrid.Types.INumberColumnExtraConfigs | OSFramework.DataGrid.Types.ICurrencyColumnExtraConfigs) {
+        constructor(
+            config:
+                | DataGrid.Types.INumberColumnExtraConfigs
+                | OSFramework.DataGrid.Types.ICurrencyColumnExtraConfigs
+        ) {
             super(config);
 
             //When both are 0, seems that we receive the default value from OS
@@ -28,8 +34,14 @@ namespace OSFramework.DataGrid.Configuration.Column {
             let provider = {
                 format: this.format,
                 isRequired: this.required,
-                min: this.minValue,
-                max: this.maxValue,
+                min:
+                    this.minValue < this.minPerDecPlaces
+                        ? this.minPerDecPlaces
+                        : this.minValue,
+                max:
+                    this.maxValue > this.maxPerDecPlaces
+                        ? this.maxPerDecPlaces
+                        : this.maxValue,
                 step: this.step
             };
 

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -174,10 +174,10 @@ namespace OSFramework.DataGrid.Types {
     export interface INumberColumnExtraConfigs extends ICommonExtraConfigs {
         decimalPlaces: number;
         hasThousandSeparator: boolean;
-        maxValue: number;
-        minValue: number;
         maxPerDecPlaces: number;
+        maxValue: number;
         minPerDecPlaces?: number;
+        minValue: number;
         step: number;
     }
 

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -176,6 +176,8 @@ namespace OSFramework.DataGrid.Types {
         hasThousandSeparator: boolean;
         maxValue: number;
         minValue: number;
+        maxPerDecPlaces: number;
+        minPerDecPlaces?: number;
         step: number;
     }
 

--- a/src/Providers/DataGrid/Wijmo/Columns/NumberColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/NumberColumn.ts
@@ -77,23 +77,39 @@ namespace Providers.DataGrid.Wijmo.Column {
         /**
          * Configure the column's editor to validate maximum values
          *
-         * @param maxValue Maximum allowed value for column. When undefined the configuration will be based on decimal places
+         * @param maxValue Maximum allowed value for column.
          */
-        private _setMaxValue(maxValue?: number) {
-            this.editorConfig.maxPerDecPlaces =
-                MaxNonDecimalValues[this.editorConfig.decimalPlaces];
-            this.editorConfig.maxValue = maxValue ?? this.editorConfig.maxValue;
+        private _setMaxValue(maxValue: number) {
+            // if both are 0, we want them to be undefined as specified in the parameter description.
+            if (maxValue === this.editorConfig.minValue && maxValue === 0) {
+                this.editorConfig.minValue = undefined;
+                this.editorConfig.maxValue = undefined;
+            } else {
+                this.editorConfig.maxValue = maxValue;
+
+                // if minValue is undefined, we want it to be 0 as specified in the parameter description.
+                if (this.editorConfig.minValue === undefined)
+                    this.editorConfig.minValue = 0;
+            }
         }
 
         /**
          * Configure the column's editor to validate minimum values
          *
-         * @param minValue Minimum allowed value for column. When undefined the configuration will be based on decimal places
+         * @param minValue Minimum allowed value for column.
          */
-        private _setMinValue(minValue?: number) {
-            this.editorConfig.minPerDecPlaces =
-                -MaxNonDecimalValues[this.editorConfig.decimalPlaces];
-            this.editorConfig.minValue = minValue ?? this.editorConfig.minValue;
+        private _setMinValue(minValue: number) {
+            // if both are 0, we want them to be undefined as specified in the parameter description.
+            if (minValue === this.editorConfig.maxValue && minValue === 0) {
+                this.editorConfig.minValue = undefined;
+                this.editorConfig.maxValue = undefined;
+            } else {
+                this.editorConfig.minValue = minValue;
+
+                // if maxValue is undefined, we want it to be 0 as specified in the parameter description.
+                if (this.editorConfig.maxValue === undefined)
+                    this.editorConfig.maxValue = 0;
+            }
         }
 
         /**
@@ -117,14 +133,11 @@ namespace Providers.DataGrid.Wijmo.Column {
                               .decimals;
             }
 
-            if (this.editorConfig.minValue > this.editorConfig.maxValue) {
-                console.warn(
-                    `The Number Column ${this.config.binding}'s  MinValue parameter must have a smaller value than the MaxValue parameter to ensure their correct behaviour. Please review those parameters values.`
-                );
-            }
-
-            this._setMaxValue();
-            this._setMinValue();
+            // update editorConfig.maxPerDecPlaces and editorConfig.minPerDecPlaces based on the decimalPlaces
+            this.editorConfig.maxPerDecPlaces =
+                MaxNonDecimalValues[this.editorConfig.decimalPlaces];
+            this.editorConfig.minPerDecPlaces =
+                -MaxNonDecimalValues[this.editorConfig.decimalPlaces];
             this._setEditorFormat(this.editorConfig.hasThousandSeparator);
         }
 

--- a/src/Providers/DataGrid/Wijmo/Columns/NumberColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/NumberColumn.ts
@@ -30,6 +30,10 @@ namespace Providers.DataGrid.Wijmo.Column {
             configs: OSFramework.DataGrid.Types.IColumnConfigs,
             editorConfig: T
         ) {
+            editorConfig.maxPerDecPlaces =
+                MaxNonDecimalValues[editorConfig.decimalPlaces];
+            editorConfig.minPerDecPlaces =
+                -MaxNonDecimalValues[editorConfig.decimalPlaces];
             super(
                 grid,
                 columnID,
@@ -76,14 +80,9 @@ namespace Providers.DataGrid.Wijmo.Column {
          * @param maxValue Maximum allowed value for column. When undefined the configuration will be based on decimal places
          */
         private _setMaxValue(maxValue?: number) {
-            const decimalPlaces = this.editorConfig.decimalPlaces;
-            const maxPerDecPlaces = MaxNonDecimalValues[decimalPlaces];
-            maxValue =
-                maxValue === undefined ? this.editorConfig.maxValue : maxValue;
-            this.editorConfig.maxValue =
-                maxValue !== undefined && maxValue < maxPerDecPlaces
-                    ? maxValue
-                    : maxPerDecPlaces;
+            this.editorConfig.maxPerDecPlaces =
+                MaxNonDecimalValues[this.editorConfig.decimalPlaces];
+            this.editorConfig.maxValue = maxValue ?? this.editorConfig.maxValue;
         }
 
         /**
@@ -92,14 +91,9 @@ namespace Providers.DataGrid.Wijmo.Column {
          * @param minValue Minimum allowed value for column. When undefined the configuration will be based on decimal places
          */
         private _setMinValue(minValue?: number) {
-            const decimalPlaces = this.editorConfig.decimalPlaces;
-            const minPerDecPlaces = -MaxNonDecimalValues[decimalPlaces];
-            minValue =
-                minValue === undefined ? this.editorConfig.minValue : minValue;
-            this.editorConfig.minValue =
-                minValue !== undefined && minValue > minPerDecPlaces
-                    ? minValue
-                    : minPerDecPlaces;
+            this.editorConfig.minPerDecPlaces =
+                -MaxNonDecimalValues[this.editorConfig.decimalPlaces];
+            this.editorConfig.minValue = minValue ?? this.editorConfig.minValue;
         }
 
         /**


### PR DESCRIPTION
This PR is for fix DecimalPlaces not updating correctly the MinValue and MaxValue limits through OnParametersChanged.

### What was happening
* When maxValue > MaxNonDecimalValues[decimalPlaces], maxValue was overwriten by MaxNonDecimalValues. This way, it was not possible to assume maxValue original value, when it went back to MaxNonDecimalValues < maxValue. The same was occurring for minValue and minPerDecPlaces

### What was done
* Two new attributes maxPerDecPlaces and minPerDecPlaces where added to EditorConfigNumber class. They store the maximum and minimum value according to the decimalPlaces set, respectively.
* The minValue and maxValue keep their original value unless and OnParametersChange event occurs
* In EditorConfigNumber.getProviderConfig, it is being validated if minPerDecPlaces or minValue should be assigned to min property of the provider's editor. Same for maxPerDecPlaces, maxValue to max property.
* Now, when the parameters change and minValue=0 and maxValue=0, they are set to undefined, so maxPerDecPlaces and minPerDecPlaces assume the editor limits.

### Test Steps
1. For a NumberColumn, set MinValue = -70000, MaxValue=70000 and DecimalPlaces=2
2. Check if the limits are respected for this column
3. Set DecimalPlaces=11
4. Check if the new limits are -65535 and 65535
5. Set DecimalPlaces=2
6. Check if the new limits are -70000 and 70000


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

