### PR TITLE
ROU-4065: SetRowAsSelected not selecting the rows as expected

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/Selection.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Selection.ts
@@ -382,45 +382,93 @@ namespace Providers.DataGrid.Wijmo.Feature {
         public getProviderAllSelections(): wijmo.grid.CellRange[] {
             const ranges: wijmo.grid.CellRange[] = [];
             const maxCol = this._grid.provider.columns.length - 1;
-            //// wijmo.grid.SelectionMode.ListBox, Row and RowRange not supported yet,
-            //// there is a conflict with wijmo.grid.selector.Selector
-            // if (this._grid.grid.selectionMode === wijmo.grid.SelectionMode.ListBox
-            //     || this._grid.grid.selectionMode === wijmo.grid.SelectionMode.Row
-            //     || this._grid.grid.selectionMode === wijmo.grid.SelectionMode.RowRange) {
-            //     rows = this._grid.grid.selectedRows
-            //         .map(p => new wijmo.grid.CellRange(p.index, 0, p.index, maxCol));
-            // }
-            // else {
+
             ranges.push(
                 ...this._grid.provider.selectedRanges.filter((p) => p.isValid)
             );
-            // }
 
-            // create checkedRows cell range.
-            let checkedRowsRange = this._getCheckedRows()
-                .map((p) => new wijmo.grid.CellRange(p, 0, p, maxCol))
-                .filter((p) => {
-                    for (let i = 0; i < ranges.length; i++) {
-                        if (ranges[i].contains(p)) return false;
-                    }
-                    return true;
-                });
+            const selectedRows: Array<number> = this._getCheckedRows(); // get checked rows index
+            const selectedRowsRanges: Array<wijmo.grid.CellRange> = [];
+            let finalRange: Array<wijmo.grid.CellRange> = [];
 
-            // for each cellRange, check if it has any intersection with checked rows
-            // if it doesnt have, we add it to checkedRows array.
-            ranges.forEach((range) => {
-                if (
-                    !checkedRowsRange.some((checked) =>
-                        checked.intersects(range)
-                    )
-                ) {
-                    checkedRowsRange = [...checkedRowsRange, range];
-                }
+            // create a range for each row
+            selectedRows.forEach((rowIndex) => {
+                const rowRange = new wijmo.grid.CellRange(
+                    rowIndex,
+                    0,
+                    rowIndex,
+                    maxCol
+                );
+
+                // add the row range created to selectedRowsRanges array
+                selectedRowsRanges.push(rowRange);
             });
 
-            return this._grid.features.rowHeader.hasCheckbox
-                ? checkedRowsRange
-                : ranges;
+            // if it the grid has checkboxes, then just return the row ranges
+            if (this._grid.features.rowHeader.hasCheckbox) {
+                finalRange = selectedRowsRanges;
+            }
+
+            // otherwise, if it has selected rows, then merge it with the selected ranges
+            else if (selectedRows.length > 0) {
+                ranges.forEach((range) => {
+                    selectedRowsRanges.forEach((rowRange) => {
+                        // for each range, check if it intersects the checked row
+                        if (range !== null && range.intersects(rowRange)) {
+                            let row1 = range.row;
+                            let row2 = range.row2;
+                            if (range.row > range.row2) {
+                                row1 = range.row2;
+                                row2 = range.row;
+                            }
+
+                            // if the range starts before the checked row,
+                            // create a new subsection of range from where it starts until the selected row index - 1
+                            // and add it to the finalRange array
+                            if (row1 < rowRange.row) {
+                                finalRange.push(
+                                    new wijmo.grid.CellRange(
+                                        row1,
+                                        range.col,
+                                        rowRange.row - 1,
+                                        range.col2
+                                    )
+                                );
+                            }
+
+                            // if the range finishes after the checked row,
+                            // create a new subsection of range from the selected row index + 1 until where it finishes
+                            // we want to use this range for the next iteration
+                            if (row2 > rowRange.row) {
+                                range = new wijmo.grid.CellRange(
+                                    rowRange.row + 1,
+                                    range.col,
+                                    row2,
+                                    range.col2
+                                );
+                            }
+                            // otherwise, there is not more range to cover, so set it null
+                            else {
+                                range = null;
+                            }
+                        }
+                    });
+
+                    // if it is not null, we push the remaining subsection of the range into the finalRange array
+                    if (range) finalRange.push(range);
+                });
+
+                // now that we are sure that the row ranges don't have intersections between the selected ranges,
+                // we can merge both arrays
+                finalRange = [...selectedRowsRanges, ...finalRange];
+            }
+
+            // otherwise, just return the selected ranges
+            else {
+                finalRange = ranges;
+            }
+
+            return finalRange;
         }
 
         public getSelectedRows(): number[] {

--- a/src/Providers/DataGrid/Wijmo/Features/Selection.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Selection.ts
@@ -404,13 +404,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 selectedRowsRanges.push(rowRange);
             });
 
-            // if it the grid has checkboxes, then just return the row ranges
-            if (this._grid.features.rowHeader.hasCheckbox) {
-                finalRange = selectedRowsRanges;
-            }
-
-            // otherwise, if it has selected rows, then merge it with the selected ranges
-            else if (selectedRows.length > 0) {
+            // if the grid has selected rows, then remove from the ranges the intersections with the selected ranges
+            if (selectedRows.length > 0) {
                 ranges.forEach((range) => {
                     selectedRowsRanges.forEach((rowRange) => {
                         // for each range, check if it intersects the checked row
@@ -423,8 +418,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
                             }
 
                             // if the range starts before the checked row,
-                            // create a new subsection of range from where it starts until the selected row index - 1
-                            // and add it to the finalRange array
+                            // we want to remove the intersection between the range and the selected row by
+                            // creating a new subsection of range from the beginning of the range until the selected row index - 1
+                            // and add it to the finalRange array.
                             if (row1 < rowRange.row) {
                                 finalRange.push(
                                     new wijmo.grid.CellRange(
@@ -437,8 +433,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
                             }
 
                             // if the range finishes after the checked row,
-                            // create a new subsection of range from the selected row index + 1 until where it finishes
-                            // we want to use this range for the next iteration
+                            // we want to remove the intersection between the range and the selected row by
+                            // creating a new subsection of range from the selected row index + 1 until the end of the range.
+                            // we will use this range for the next iteration to check if it does not  rowintersects any other selected.
                             if (row2 > rowRange.row) {
                                 range = new wijmo.grid.CellRange(
                                     rowRange.row + 1,


### PR DESCRIPTION
This PR is for fix the selection not getting all the rows and ranges correctly.

### What was happening
* The getProviderAllSelections was not returning the rows selected using SetRowAsSelected method in a grid without checkboxes.
* The getProviderAllSelections was not returning the correct ranges when a range intersect the selected row via checkboxes in a grid with checkboxes.

### What was done
* Implemented a solution that merge the selected rows to the ranges removing the duplicated cells when an intersection between row and range is found.
* Change the behaviour to always get all the ranges and rows selected in a grid with checkboxes.

### Test Steps
Test 1: 
1. Select some rows of the DataGrid using SetRowsAsSelected()
2. Call GetAllSelections, GetAllSelectionsData, GetSelectedRowsCount, GetSelectedRowsData, GetSelectionAverage, GetSelectionCount, GetSelectionMax, GetSelectionMin, GetSelectionSum and check if the result is the expected.

Test 2:
1. Select some rows of the DataGrid using SetRowsAsSelected()
2. Select any range of cells 
3. Call GetAllSelections, GetAllSelectionsData, GetSelectedRowsCount, GetSelectedRowsData, GetSelectionAverage, GetSelectionCount, GetSelectionMax, GetSelectionMin, GetSelectionSum and check if the result is the expected.

Test 3:
1. Select some rows of the DataGrid with checkboxes in rows header.
2. Select any range of cells.
3. Call GetAllSelections, GetAllSelectionsData, GetSelectedRowsCount, GetSelectedRowsData, GetSelectionAverage, GetSelectionCount, GetSelectionMax, GetSelectionMin, GetSelectionSum and check if the result is the expected.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

