### PR TITLE
ROU-4077: Allow developers to control  the Tab key action for accessibility reasons

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/TabNavigation.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/TabNavigation.ts
@@ -19,8 +19,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
         public setState(value: boolean): void {
             this._grid.provider.keyActionTab = value
-                ? wijmo.grid.KeyAction.Cycle
-                : wijmo.grid.KeyAction.None;
+                ? wijmo.grid.KeyAction.CycleOut // Move the selection to the next column, then wrap to the next row, then out of the control.
+                : wijmo.grid.KeyAction.None; // No special action (let the browser handle the key). The arrow keys will be used to navigate the grid.
             this._enabled = value;
         }
     }


### PR DESCRIPTION
This PR is for change the default TabNavigation behaviour.

### What was happening
* There was an accessibility issue when using the Tab key inside the Grid. Once inside the Grid it is not possible to get out using the Tab key.

### What was done
* In Service Studio, changed the allowKeyTabNavigation internal config value from "True" to "False", so the default behavior is the arrow navigation inside the Grid, and the Tab key is used to get in and out of it.
* In the code, changed from "Cycle" to "CycleOut" mode in TabNavigation feature, that makes it possible to use the tab navigation and get out of the Grid using Tab key.

### Test Steps
1. Go to a page with DataGrid Reactive.
2. Check if it is possible to get in and out the Grid using Tab key and navigate inside it using the arrow keys.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

