### PR TITLE
ROU-4150: Issue in column HeaderTooltip when column name match with tooltip text

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -38,7 +38,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
             }
         }
 
-        private _onMouseOut(/*e: Event*/): void {
+        private _onMouseOut(): void {
             this._toolTip.hide();
         }
 

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -20,7 +20,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         private _onMouseEnter(e: MouseEvent): void {
-            let _currTarget: HTMLElement = e.currentTarget as HTMLElement;
+            const _currTarget: HTMLElement = e.currentTarget as HTMLElement;
             const ht = this._grid.provider.hitTest(e);
 
             const cellType = this._grid.provider.hitTest(_currTarget).cellType;


### PR DESCRIPTION
This PR is for prevent the tooltip to be set with its column preview when column name match with tooltip text. Corrected the HeaderTooltip not being set correctly when the grid has repeated binding in different columns

### What was happening
* When the column name matches with tooltip text, the tooltip was set with its column preview.
* When two columns have the same binding, the header tooltip was not set correctly for one of them.
* Sometimes the header tooltip was not appearing unless some modification was made in the column (resizing the column for example).

### What was done
* Add a condition to check when the column name matches the tooltip text, if true, then the column header will be set to the tooltip.
* Instead of using Tooltip.setTooltip() the tooltip in MouseOver event, now we are using Tooltip.show().
* Instead of get the column configs by the binding, now we use the column index.

### Test Steps
1. In a grid, set the Column Name equals to the HeaderTooltip text. 
2. Click publish.
3. Check if the header tooltip is equal to the header title.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

