### PR TITLE
ROU-4179: Issue with HeaderTooltip when scrolling the page

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -21,9 +21,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
         private _onMouseEnter(e: MouseEvent): void {
             const _currTarget: HTMLElement = e.currentTarget as HTMLElement;
-            const ht = this._grid.provider.hitTest(e);
+            const ht = this._grid.provider.hitTest(_currTarget);
 
-            const cellType = this._grid.provider.hitTest(_currTarget).cellType;
+            const cellType = ht.cellType;
             if (
                 cellType === wijmo.grid.CellType.Cell ||
                 cellType === wijmo.grid.CellType.ColumnFooter


### PR DESCRIPTION
This PR is for fix the issue with the tooltip when scrolling the page.

### What was happening
* When you scrolling the mouse over the cell, the hitTest return an invalid cell.

### What was done
* Changed the hitTest argument from MouseEvent to the cell's HTMLElement.

### Test Steps
1. Go to a page with a Grid
2. Open the DevTools
3. Scroll the mouse over a Grid cell
Expected: No error is raised.

### Checklist
* [x] tested locally
* [ ] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

