### PR TITLE
ROU-4200: Showing invalid tooltip when cell is valid

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -51,7 +51,10 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 cell.innerText
             );
 
-            const isInvalid = cell.classList.contains('wj-state-invalid');
+            const isInvalid = this._grid.features.validationMark.isInvalid(
+                row,
+                binding
+            );
 
             if (cell.querySelector('div.dg-cell')) {
                 cell = cell.querySelector('div.dg-cell');

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -69,6 +69,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
         ): void {
             if (!e.cancel) {
                 const column = s.getColumn(e.col);
+                const cell = s.cells.getCellElement(e.row, e.col);
+
                 const OSColumn = this._grid
                     .getColumns()
                     .find((item) => item.provider.index === column.index);
@@ -86,6 +88,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     oldValue,
                     newValue
                 );
+
+                this._checkInvalidCell(e.panel.cellType, e.row, e.col, cell);
             }
         }
 
@@ -120,16 +124,22 @@ namespace Providers.DataGrid.Wijmo.Feature {
             grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.FormatItemEventArgs
         ) {
+            this._checkInvalidCell(e.panel.cellType, e.row, e.col, e.cell);
+        }
+
+        private _checkInvalidCell(cellType, row, col, cell) {
             if (
-                e.panel.cellType === wijmo.grid.CellType.Cell &&
-                this._isInvalidCell(e.row, e.col)
+                cellType === wijmo.grid.CellType.Cell &&
+                this._isInvalidCell(row, col)
             ) {
-                wijmo.addClass(e.cell, 'wj-state-invalid');
+                wijmo.addClass(cell, 'wj-state-invalid');
             } else if (
-                e.panel.cellType === wijmo.grid.CellType.RowHeader &&
-                this._isInvalidRowByRowNumber(e.row)
+                cellType === wijmo.grid.CellType.RowHeader &&
+                this._isInvalidRowByRowNumber(row)
             ) {
-                wijmo.addClass(e.cell, 'wj-state-invalid');
+                wijmo.addClass(cell, 'wj-state-invalid');
+            } else {
+                wijmo.removeClass(cell, 'wj-state-invalid');
             }
         }
 

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -69,8 +69,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
         ): void {
             if (!e.cancel) {
                 const column = s.getColumn(e.col);
-                const cell = s.cells.getCellElement(e.row, e.col);
-
                 const OSColumn = this._grid
                     .getColumns()
                     .find((item) => item.provider.index === column.index);
@@ -88,8 +86,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     oldValue,
                     newValue
                 );
-
-                this._checkInvalidCell(e.panel.cellType, e.row, e.col, cell);
             }
         }
 
@@ -124,22 +120,16 @@ namespace Providers.DataGrid.Wijmo.Feature {
             grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.FormatItemEventArgs
         ) {
-            this._checkInvalidCell(e.panel.cellType, e.row, e.col, e.cell);
-        }
-
-        private _checkInvalidCell(cellType, row, col, cell) {
             if (
-                cellType === wijmo.grid.CellType.Cell &&
-                this._isInvalidCell(row, col)
+                e.panel.cellType === wijmo.grid.CellType.Cell &&
+                this._isInvalidCell(e.row, e.col)
             ) {
-                wijmo.addClass(cell, 'wj-state-invalid');
+                wijmo.addClass(e.cell, 'wj-state-invalid');
             } else if (
-                cellType === wijmo.grid.CellType.RowHeader &&
-                this._isInvalidRowByRowNumber(row)
+                e.panel.cellType === wijmo.grid.CellType.RowHeader &&
+                this._isInvalidRowByRowNumber(e.row)
             ) {
-                wijmo.addClass(cell, 'wj-state-invalid');
-            } else {
-                wijmo.removeClass(cell, 'wj-state-invalid');
+                wijmo.addClass(e.cell, 'wj-state-invalid');
             }
         }
 


### PR DESCRIPTION
This PR is for fix showing invalid tooltip when cell is valid.

### What was happening
* The Tooltip's onMouseEnter event listener was trigger before the "wj-state-invalid" cell class is removed

### What was done
* Now, instead of check if the "wj-state-invalid" is a cell class, we use the isInvalid method from the ValidationMark feature. 

### Test Steps
1. Go to the test page
2. Click to edit a cell to an invalid value
3. Press enter
4. Click to edit a cell to an invalid value
Expected: Check that no error tooltip appears.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

