### PR TITLE
ROU-4205: Issue with undo action after Server Side search

### DIFF
--- a/src/OSFramework/DataGrid/Feature/IUndoStack.ts
+++ b/src/OSFramework/DataGrid/Feature/IUndoStack.ts
@@ -6,6 +6,10 @@ namespace OSFramework.DataGrid.Feature {
     export interface IUndoStack {
         stack: wijmo.undo.UndoStack;
         /**
+         * Clear the UndoStack
+         */
+        clear();
+        /**
          * Close a pending action, has to be call after the startAction and after the desired changed
          * @param T  Type of the Pending action, used to verify if the pending action waiting to be closed has the same type
          */

--- a/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
@@ -324,6 +324,7 @@ namespace OSFramework.DataGrid.Grid {
 
         public setData(data: string): boolean {
             this.dataSource.setData(data);
+            this.features.undoStack.clear();
 
             if (this.isReady) {
                 if (!this.hasColumnsDefined()) {

--- a/src/Providers/DataGrid/Wijmo/Features/UndoStack.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/UndoStack.ts
@@ -38,6 +38,10 @@ namespace Providers.DataGrid.Wijmo.Feature {
             );
         }
 
+        public clear(): void {
+            this._undoStack.clear();
+        }
+
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
         public closeAction<T>(T): void {
             this._undoStack._pendingAction instanceof T &&


### PR DESCRIPTION
This PR is for fix issue with undo action after Server Side search

### What was happening
* The undo action was happening in the wrong rows after data source refresh due to the server side search.

### What was done
* Clear undo stack when the data source is updated.

### Test Steps
1. In a grid, add a new row
2. Fill the empty cells with data
3. Perform a server side search
4. Check that it is not possible to undo any action. 


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

