### PR TITLE
ROU-4207: Tooltip errorValidation class is not removed properly

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -121,6 +121,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
             if (isInvalid === true) this._toolTip.cssClass = 'errorValidation';
             else {
                 this._toolTip.cssClass = '';
+
+                // Implementation of the workaround provided by Wijmo related to ROU-4207 issue.
+                // To be removed after Wijmo fix.
                 if (wijmo.Tooltip._eTip)
                     wijmo.Tooltip._eTip.setAttribute('class', 'wj-tooltip');
             }

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -72,6 +72,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 ) {
                     //JS asserts the previous declaration as true when they are equal
                     this._toolTip.show(cell, sanitizedValue); // show tooltip if text is overflow/hidden
+                } else {
+                    this._toolTip.hide();
                 }
             }
             //Otherwise (If the cell is invalid)
@@ -117,7 +119,11 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
         private _toolTipClass(isInvalid: boolean): void {
             if (isInvalid === true) this._toolTip.cssClass = 'errorValidation';
-            else this._toolTip.cssClass = '';
+            else {
+                this._toolTip.cssClass = '';
+                if (wijmo.Tooltip._eTip)
+                    wijmo.Tooltip._eTip.setAttribute('class', 'wj-tooltip');
+            }
         }
 
         public build(): void {


### PR DESCRIPTION
This PR is for fix the tooltip class error.

### What was happening:
* When an invalid cell was edited to a valid value, then the error class is not properly removed from the tooltip, and all the other tooltips were displayed as error tooltips (with background red).

### What was done
* Implemented the workaround provided by wijmo expert:
   * Set the class attribute directly in the tooltip element.
* This implementation will be removed after wijmo release. 

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

