### PR TITLE
ROU-4230: Escape key does not cancel cell editing

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -42,6 +42,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
             s: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
+            // if the ESC key is pressed the e.cancel is true
+            if (e.cancel) return;
+
             // get the new value
             const newValue = s.activeEditor?.value ?? '';
             let currentValue = '';


### PR DESCRIPTION
This PR is for cancel cell editing if ESC key was pressed

### What was happening
* When Esc is pressed while editing, it should cancel the editing, but it did not happen.

### What was done
* Check if "cancel" property of wijmo.grid.CellRangeEventArgs is true in _cellEditBeforeEndingHandler. 
    * If true, return; else proceed with the cell editing.

### Test Steps
1. Go to a page with a Grid
2. Edit any cell value
3. Before finish editing, press ESC key
4. Check if the previous cell value is restored.

### Screenshots
![esckeyerror](https://user-images.githubusercontent.com/108938618/230103009-aade8130-d1d0-4527-bcde-970548cb4470.gif)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

