### PR TITLE
Update OutSystems DataGrid version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "outsystems-datagrid",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/lodash": "^4.14.169",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "OutSystems Data Grid for Reactive Web",
   "author": "UI Components Team",
   "license": "BSD-3-Clause",

--- a/src/OSFramework/DataGrid/Constants.ts
+++ b/src/OSFramework/DataGrid/Constants.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.DataGrid.Constants {
     /* OutSystems Data Grid Version */
-    export const OSDataGridVersion = '2.11.0';
+    export const OSDataGridVersion = '2.12.0';
 }


### PR DESCRIPTION
This PR is for update OutSystems DataGrid version to 2.12.0.
