### PR TITLE
Changed ClearFilter to allow triggering OnFiltersChange event

### DIFF
--- a/src/OSFramework/DataGrid/Configuration/Column/EditorConfigDate.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/EditorConfigDate.ts
@@ -10,7 +10,10 @@ namespace OSFramework.DataGrid.Configuration.Column {
         public min: Date;
 
         // eslint-disable-next-line
-        constructor(config: DataGrid.Types.IDateColumnExtraConfigs, isDateTime: boolean) {
+        constructor(
+            config: DataGrid.Types.IDateColumnExtraConfigs,
+            isDateTime: boolean
+        ) {
             super(config);
             this.defaultFormat = `${OutSystems.GridAPI.dateFormat}${
                 isDateTime ? ' HH:mm' : ''

--- a/src/OSFramework/DataGrid/Feature/IColumnFilter.ts
+++ b/src/OSFramework/DataGrid/Feature/IColumnFilter.ts
@@ -16,7 +16,7 @@ namespace OSFramework.DataGrid.Feature {
             columnID: string,
             filterType: wijmo.grid.filter.FilterType
         ): void;
-        clear(columnID: string): void;
+        clear(columnID: string, triggerOnFiltersChange?: boolean): void;
         deactivate(columnID: string): void;
         setColumnFilterOptions(
             columnID: string,

--- a/src/OutSystems/GridAPI/Filter.ts
+++ b/src/OutSystems/GridAPI/Filter.ts
@@ -93,16 +93,24 @@ namespace OutSystems.GridAPI.Filter {
      * @export
      * @param {string} gridID ID of the Grid that is to be to check from results.
      * @param {string} columnID ID of the column that will have filter cleared.
+     * @param {boolean} [triggerOnFiltersChange=true] Flag to indicate if the OnFiltersChange event is to be triggered or not.
      * @returns {*}  {string} Return Message Success or message of error info if it's the case.
      */
-    export function Clear(gridID: string, columnID: string): string {
+    export function Clear(
+        gridID: string,
+        columnID: string,
+        triggerOnFiltersChange = true
+    ): string {
         Performance.SetMark('Filter.clear');
         const result = Auxiliary.CreateApiResponse({
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedFilterClear,
             callback: () => {
-                GridManager.GetGridById(gridID).features.filter.clear(columnID);
+                GridManager.GetGridById(gridID).features.filter.clear(
+                    columnID,
+                    triggerOnFiltersChange
+                );
             }
         });
 

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -250,16 +250,21 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         /**
-         * Function that will Clear a column Filter at a given ColumnID
+         * Function that will Clear a column Filter at a given ColumnID.
          *
-         * @param columnId Column Id where the Filter will be performed
+         * @param {string} columnID Column Id where the Filter will be performed.
+         * @param {boolean} [triggerOnFiltersChange=true] Flag to indicate if the OnFiltersChange event is to be triggered or not.
+         * @memberof ColumnFilter
          */
-        public clear(columnID: string): void {
+        public clear(columnID: string, triggerOnFiltersChange = true): void {
             const column = this._grid.getColumn(columnID);
 
             if (column) {
                 this._filter.getColumnFilter(column.provider).clear();
                 this._grid.provider.collectionView.refresh();
+                if (triggerOnFiltersChange) {
+                    this._filterChangedHandler(this._filter);
+                }
             } else {
                 throw new Error(
                     OSFramework.DataGrid.Enum.ErrorMessages.InvalidColumnIdentifier


### PR DESCRIPTION
This PR is to implement a way to trigger the OnFiltersChange event when using the ClearFilter.

### What was happening
* When using the Filters API, only the ClearFilter was not triggering the OnFiltersChange event.

### What was done
* Changed ClearFilter to allow triggering OnFiltersChange event

### Test Steps
1. Go to GridReactive_Automation_ROU4340/API_Filter
2. Clicked in Filter by Value
3. Checked that the Server Side Grid was filtered and the OnFiltersChange event triggered
4. Clicked in Filter Clear
5. Checked that the Server Side Grid got the filters cleared and the OnFiltersChange event triggered
6. Do the same using the Grid filters to filter and clear, checking that the OnFiltersChange event triggered



### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

