### PR TITLE
ROU-4367: Fixed issue in moveToPage error handling

### DIFF
--- a/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
+++ b/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
@@ -26,7 +26,7 @@ namespace OSFramework.DataGrid.Enum {
         Row_NotFound = 'Row not found.',
         SetCurrentPage = 'An error occurred while trying to set current page.',
         SetCurrentPageServerSidePagination = 'It seems that you have server side pagination turned on. Switch it off and try again.',
-        SetRowAsSelected = 'Grids with RowCheckbox as RowHeader has this capability disabled.',
+        SetRowAsSelected = 'Grids with RowCheckbox as RowHeader have this capability disabled.',
         SuccessMessage = 'Success',
         UnableToAddRow = 'Unable to add row. Please use ArrangeData action to serialize your data.',
         RemoveRowErrorMessage = 'An error occurred while trying to remove rows.'

--- a/src/OutSystems/GridAPI/Pagination.ts
+++ b/src/OutSystems/GridAPI/Pagination.ts
@@ -190,7 +190,7 @@ namespace OutSystems.GridAPI.Pagination {
                     );
                 }
 
-                if (grid.features.pagination.moveToPage(n)) {
+                if (!grid.features.pagination.moveToPage(n)) {
                     throw new Error(
                         OSFramework.DataGrid.Enum.ErrorMessages.SetCurrentPage
                     );


### PR DESCRIPTION
This PR is for fixing an issue in the `moveToPage()` method that was always throwing an error.

### What was happening
* Even in the case of a successful call, the client action **SetCurrentPage** was throwing an error.

### What was done
* Fixed the condition that was throwing the error.

### Test Steps
1. Go to GridReactive_Automation_ROU4367/API
2. Add the page to go in the input set as 5
3. Click in "Set Current Page"
4. Check that the page changed and no error was returned


### Screenshots
![image](https://github.com/OutSystems/outsystems-datagrid/assets/29493222/c24461d7-fd80-4747-80b3-bc7273b68735)



### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

