### PR TITLE
ROU-4350: Changing context menu to return the correct Id of the column in the Toggle event

### DIFF
--- a/src/OSFramework/DataGrid/Event/Feature/ContextMenuEventManager.ts
+++ b/src/OSFramework/DataGrid/Event/Feature/ContextMenuEventManager.ts
@@ -42,7 +42,7 @@ namespace OSFramework.DataGrid.Event.Feature {
                     .trigger(
                         this._contextMenu.grid.widgetId,
                         this._contextMenu.isOpening,
-                        this._contextMenu.columnUniqueId
+                        this._contextMenu.columnId
                     );
             }
         }

--- a/src/OSFramework/DataGrid/Feature/IContextMenu.ts
+++ b/src/OSFramework/DataGrid/Feature/IContextMenu.ts
@@ -8,7 +8,10 @@ namespace OSFramework.DataGrid.Feature {
          * Getter for the contextMenu events
          */
 
+        columnBinding: string;
+        columnId: string;
         columnUniqueId: string;
+        columnWidgetId: string;
         contextMenuEvents: Event.Feature.ContextMenuEventManager;
         /**
          * Grid's reference

--- a/src/OSFramework/DataGrid/Helper/CheckPlatformId.ts
+++ b/src/OSFramework/DataGrid/Helper/CheckPlatformId.ts
@@ -1,0 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.DataGrid.Helper {
+    /**
+     * Regular expression that enables to identify if the widget Id was given by the developer or not.
+     */
+    const RegExHasDefaultPlatformId = /^\$b\d{1,5}$/;
+
+    export function HasPlatformDefaultId(widgetId: string): boolean {
+        let isDefaultId = false;
+        if (widgetId) {
+            isDefaultId = widgetId.search(RegExHasDefaultPlatformId) > -1;
+        }
+        return isDefaultId;
+    }
+}

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -10,7 +10,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
             OSFramework.DataGrid.Feature.IContextMenu
     {
         /** Events from the Context Menu  */
+        private _columnBinding: string;
         private _columnUniqueId: string;
+        private _columnWidgetId: string;
         private _contextMenuEvents: OSFramework.DataGrid.Event.Feature.ContextMenuEventManager;
         private _grid: Grid.IGridWijmo;
         private _isOpening: boolean;
@@ -244,9 +246,15 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
             // Will need to have an extra validation looking at the binding because of the column picker column
             if (columns.length && htColumn && htColumn.binding !== null) {
-                this._columnUniqueId = this._grid.getColumns().find((x) => {
+                const columnHit = this._grid.getColumns().find((x) => {
                     return x.config.binding === htColumn.binding;
-                }).uniqueId;
+                });
+                this._columnBinding = columnHit.config.binding;
+                this._columnUniqueId = columnHit.uniqueId;
+                //If the id of the widget id stars with a $, means that the developer didn't set the Id. So it's not useful to return it.
+                this._columnWidgetId = columnHit.widgetId.startsWith('$')
+                    ? ''
+                    : columnHit.widgetId;
             }
 
             this._contextMenuEvents.trigger(
@@ -301,8 +309,24 @@ namespace Providers.DataGrid.Wijmo.Feature {
             return this._isOpening;
         }
 
+        public get columnBinding(): string {
+            return this._columnBinding;
+        }
+
+        public get columnId(): string {
+            return (
+                this._columnWidgetId ||
+                this._columnBinding ||
+                this._columnUniqueId
+            );
+        }
+
         public get columnUniqueId(): string {
             return this._columnUniqueId;
+        }
+
+        public get columnWidgetId(): string {
+            return this._columnWidgetId;
         }
 
         public get grid(): OSFramework.DataGrid.Grid.IGrid {

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -252,9 +252,10 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 this._columnBinding = columnHit.config.binding;
                 this._columnUniqueId = columnHit.uniqueId;
                 //If the id of the widget id stars with a $, means that the developer didn't set the Id. So it's not useful to return it.
-                this._columnWidgetId = columnHit.widgetId.startsWith('$')
-                    ? ''
-                    : columnHit.widgetId;
+                this._columnWidgetId =
+                    columnHit.widgetId && columnHit.widgetId.startsWith('$')
+                        ? ''
+                        : columnHit.widgetId;
             }
 
             this._contextMenuEvents.trigger(

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -249,13 +249,19 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 const columnHit = this._grid.getColumns().find((x) => {
                     return x.config.binding === htColumn.binding;
                 });
-                this._columnBinding = columnHit.config.binding;
-                this._columnUniqueId = columnHit.uniqueId;
-                //If the id of the widget id stars with a $, means that the developer didn't set the Id. So it's not useful to return it.
-                this._columnWidgetId =
-                    columnHit.widgetId && columnHit.widgetId.startsWith('$')
-                        ? ''
-                        : columnHit.widgetId;
+                if (columnHit) {
+                    this._columnBinding = columnHit.config.binding;
+                    this._columnUniqueId = columnHit.uniqueId;
+                    //If the id of the widget id stars with a $, means that the developer didn't set the Id. So it's not useful to return it.
+                    this._columnWidgetId = columnHit.widgetId;
+                    if (
+                        OSFramework.DataGrid.Helper.HasPlatformDefaultId(
+                            columnHit.widgetId
+                        )
+                    ) {
+                        this._columnWidgetId = '';
+                    }
+                }
             }
 
             this._contextMenuEvents.trigger(
@@ -314,12 +320,18 @@ namespace Providers.DataGrid.Wijmo.Feature {
             return this._columnBinding;
         }
 
+        /**
+         * Returns the Id of the column in which the context menu was
+         * triggered in. Tries to return the widgetId (if the dev gave one to the column block),
+         * and if not available, returns the uniqueId.
+         * In the case of auto-generated grids, the uniqueId will be equal to the column binding.
+         *
+         * @readonly
+         * @type {string}
+         * @memberof ContextMenu
+         */
         public get columnId(): string {
-            return (
-                this._columnWidgetId ||
-                this._columnBinding ||
-                this._columnUniqueId
-            );
+            return this._columnWidgetId || this._columnUniqueId;
         }
 
         public get columnUniqueId(): string {

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -252,7 +252,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 if (columnHit) {
                     this._columnBinding = columnHit.config.binding;
                     this._columnUniqueId = columnHit.uniqueId;
-                    //If the id of the widget id stars with a $, means that the developer didn't set the Id. So it's not useful to return it.
+                    //If the id of the widget id starts with a $, means that the developer didn't set the Id. So it's not useful to return it.
                     this._columnWidgetId = columnHit.widgetId;
                     if (
                         OSFramework.DataGrid.Helper.HasPlatformDefaultId(


### PR DESCRIPTION
This PR is for changing the column ID returned in the event OnMenuToggle. Currently was returning the uniqueId of the column. This implied that if the developer would have to use our JS apis to obtain the information that would help him in his endeavors. 

### What was happening
* The unique ID of the column in which the contextMenu is being displayed, was being returned. 

### What was done
* Created a new function to check if the block has a default Id generated by the platform
* The ID returned now depends of:
   * if the developer used auto-generated: column binding (as it was now)
   * if the developer used columns: 
      * defined widget name: the widget ID is returned
      * didn't defined the widget name: the column unique is returned

### Test Steps
1. Create 2 simple grids:
  a. one auto generated
  b. with columns, and give a widget name to one of the columns and none to another
2. Publish and right click in each column, and validate the column Id returned


### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

