### PR TITLE
ROU-4386: ContextMenu - avoid raising twice ToggleEvent when opening

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -99,12 +99,17 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     },
                     isDroppedDownChanging: (e) => {
                         // The event is raised when the context menu opens or closes.
-                        // It is easier to understand if it will open instead of analysing if the menu is dropped down.
-                        this._isOpening = !e.isDroppedDown;
-                        this._contextMenuEvents.trigger(
-                            OSFramework.DataGrid.Event.Feature
-                                .ContextMenuEventType.Toggle
-                        );
+
+                        //If the menu is (currently) open, then this event was fired to close it.
+                        //Otherwise, if closed, means that it will open, so we'll not do anything here.
+                        if (e.isDroppedDown) {
+                            // It is easier to understand if it will open instead of analysing if the menu is dropped down.
+                            this._isOpening = false;
+                            this._contextMenuEvents.trigger(
+                                OSFramework.DataGrid.Event.Feature
+                                    .ContextMenuEventType.Toggle
+                            );
+                        }
                     }
                 }
             );


### PR DESCRIPTION
When the context menu event is opening.

This PR is for fixing the behavior in which the ContextMenu was raising the event of Toggle twice, when the ContextMenu was being open.

### What was happening
* The context menu was raising twice the toggle event when it was opening

### What was done
* Protected the place where the event was being inadvertently raised
* The event in this place, will now only be raised when the ContextMenu is closing

### Test Steps
1. Right click on any column - context menu opens, and the message of it opening should finish with `(1)` in the end
2. Repeat the operation to another column - the message should end with `(2)`
3. Repeat 2. - the message should end with `(3)`


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

