### PR TITLE
ROU-4373: Changing language load mechanism

### DIFF
--- a/src/OutSystems/GridAPI/Language.ts
+++ b/src/OutSystems/GridAPI/Language.ts
@@ -4,16 +4,52 @@ namespace OutSystems.GridAPI.Language {
      *
      * @export
      * @param {string} language
+     * @param {string} filePath
+     */
+    export function AddSupportedLanguage(
+        language: string,
+        filePath: string
+    ): void {
+        Performance.SetMark('Language.AddSupportedLanguage');
+
+        if (language !== '') {
+            Providers.DataGrid.Wijmo.Language.AddLanguage(language, filePath);
+        }
+
+        Performance.SetMark('Language.AddSupportedLanguage-end');
+        Performance.GetMeasure(
+            '@datagrid-Language.AddSupportedLanguage',
+            'Language.AddSupportedLanguage',
+            'Language.AddSupportedLanguage-end'
+        );
+    }
+
+    export function HaveLanguagesBeenSet(): boolean {
+        Performance.SetMark('Language.HaveLanguagesBeenSet');
+
+        const result = Providers.DataGrid.Wijmo.Language.HaveLanguagesBeenSet();
+
+        Performance.SetMark('Language.HaveLanguagesBeenSet-end');
+        Performance.GetMeasure(
+            '@datagrid-Language.HaveLanguagesBeenSet',
+            'Language.HaveLanguagesBeenSet',
+            'Language.HaveLanguagesBeenSet-end'
+        );
+        return result;
+    }
+
+    /**
+     *
+     *
+     * @export
+     * @param {string} language
      * @param {string} url
      */
-    export function SetLanguage(language: string, url: string): void {
+    export function SetLanguage(language: string): void {
         Performance.SetMark('Language.SetLanguage');
 
         if (language !== '') {
-            Providers.DataGrid.Wijmo.Helper.Translation.SetLanguage(
-                language,
-                url
-            );
+            Providers.DataGrid.Wijmo.Helper.Translation.SetLanguage(language);
         }
 
         Performance.SetMark('Language.SetLanguage-end');
@@ -39,7 +75,7 @@ namespace GridAPI {
             OSFramework.DataGrid.Helper.LogWarningMessage(
                 `${OSFramework.DataGrid.Helper.warningMessage} 'OutSystems.GridAPI.Language.SetLanguage()'`
             );
-            return OutSystems.GridAPI.Language.SetLanguage(language, url);
+            return OutSystems.GridAPI.Language.SetLanguage(language);
         }
     }
 }

--- a/src/OutSystems/GridAPI/Language.ts
+++ b/src/OutSystems/GridAPI/Language.ts
@@ -71,7 +71,7 @@ namespace GridAPI {
          * @param {string} language
          * @param {string} url
          */
-        export function SetLanguage(language: string, url: string): void {
+        export function SetLanguage(language: string): void {
             OSFramework.DataGrid.Helper.LogWarningMessage(
                 `${OSFramework.DataGrid.Helper.warningMessage} 'OutSystems.GridAPI.Language.SetLanguage()'`
             );

--- a/src/Providers/DataGrid/Wijmo/Helper/Translation.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/Translation.ts
@@ -1,27 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Providers.DataGrid.Wijmo.Helper.Translation {
-    function transposeLanguageFormat(language: string): string {
-        let changedLang = language;
-
-        switch (language) {
-            //the following languages exist in these variants
-            case 'ar-AE':
-            case 'ar-SA':
-            case 'de-CH':
-            case 'en-CA':
-            case 'de-GB':
-            case 'mn-MN':
-            case 'zh-HK':
-            case 'zh-TW':
-                break;
-            //all other languages, the provider doesn't have a local variant
-            default:
-                changedLang = language.substring(0, 2);
-        }
-
-        return changedLang;
-    }
-
     export function FormatDateOperators(): void {
         const dateOperators =
             wijmo.culture.FlexGridFilter.numberOperators.filter(function (
@@ -34,36 +12,37 @@ namespace Providers.DataGrid.Wijmo.Helper.Translation {
         wijmo.culture.FlexGridFilter.dateOperators = dateOperators;
     }
 
-    export function SetLanguage(language: string, url: string): void {
-        const regex = new RegExp('culture.(.*)(?=.min)');
-        const transposedLanguage = transposeLanguageFormat(language);
+    export function SetLanguage(language: string): void {
+        if (DataGrid.Wijmo.Language.IsLanguageSupported(language)) {
+            const url = DataGrid.Wijmo.Language.GetLanguageFilePath(language);
 
-        url = url.replace(url.match(regex)[1], transposedLanguage);
-
-        fetch(url, { method: 'HEAD' }).then(function (response) {
-            if (response.ok) {
-                // this callback is wijmo's workaround to translate the group panel. Remove once they've fixed
-                OSFramework.DataGrid.Helper.DynamicallyLoadScript(
-                    url,
-                    function () {
-                        const gps = document.body.querySelectorAll(
-                            '.wj-control.wj-grouppanel'
-                        );
-                        const culture = wijmo.culture;
-                        for (let i = 0; i < gps.length; i++) {
-                            const gp = wijmo.Control.getControl(gps[i]);
-                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                            // @ts-ignore
-                            gp.placeholder = culture.GroupPanel.dragDrop;
+            fetch(url, { method: 'HEAD' }).then(function (response) {
+                if (response.ok) {
+                    // this callback is wijmo's workaround to translate the group panel. Remove once they've fixed
+                    OSFramework.DataGrid.Helper.DynamicallyLoadScript(
+                        url,
+                        () => {
+                            const gps = document.body.querySelectorAll(
+                                '.wj-control.wj-grouppanel'
+                            );
+                            const culture = wijmo.culture;
+                            for (let i = 0; i < gps.length; i++) {
+                                const gp = wijmo.Control.getControl(gps[i]);
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore
+                                gp.placeholder = culture.GroupPanel.dragDrop;
+                            }
+                            FormatDateOperators();
+                            wijmo.Control.invalidateAll();
                         }
-                        FormatDateOperators();
-                        wijmo.Control.invalidateAll();
-                    }
-                );
-            } else {
-                //if the language resource is not found in the server, then throw an error and let the english be the default language.
-                throw `The language "${language}" is not supported. Falling back to the language in use.`;
-            }
-        });
+                    );
+                } else {
+                    //if the language resource is not found in the server, then throw an error and let the english be the default language.
+                    throw `The language "${language}" is not supported. Falling back to the language in use.`;
+                }
+            });
+        } else {
+            throw `The language "${language}" is not supported. Falling back to the language in use.`;
+        }
     }
 }

--- a/src/Providers/DataGrid/Wijmo/Language/Languages.ts
+++ b/src/Providers/DataGrid/Wijmo/Language/Languages.ts
@@ -11,7 +11,8 @@ namespace Providers.DataGrid.Wijmo.Language {
             case 'ar-SA':
             case 'de-CH':
             case 'en-CA':
-            case 'de-GB':
+            case 'en-GB':
+            case 'es-MX':
             case 'mn-MN':
             case 'zh-HK':
             case 'zh-TW':

--- a/src/Providers/DataGrid/Wijmo/Language/Languages.ts
+++ b/src/Providers/DataGrid/Wijmo/Language/Languages.ts
@@ -1,0 +1,50 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace Providers.DataGrid.Wijmo.Language {
+    const _languagesURL: Map<string, string> = new Map<string, string>();
+
+    function transposeLanguageFormat(languageCode: string): string {
+        let changedLang = languageCode;
+
+        switch (languageCode) {
+            //the following languages exist in these variants
+            case 'ar-AE':
+            case 'ar-SA':
+            case 'de-CH':
+            case 'en-CA':
+            case 'de-GB':
+            case 'mn-MN':
+            case 'zh-HK':
+            case 'zh-TW':
+                break;
+            //all other languages, the provider doesn't have a local variant
+            default:
+                changedLang = languageCode.substring(0, 2);
+        }
+
+        return changedLang;
+    }
+
+    export function AddLanguage(languageCode: string, filePath: string): void {
+        if (_languagesURL.has(languageCode) === false) {
+            _languagesURL.set(languageCode, filePath);
+        }
+    }
+
+    export function GetLanguageFilePath(languageCode: string): string {
+        const tLanguageCode = transposeLanguageFormat(languageCode);
+        let pathFile = undefined;
+
+        if (_languagesURL.has(tLanguageCode)) {
+            pathFile = _languagesURL.get(tLanguageCode);
+        }
+        return pathFile;
+    }
+
+    export function HaveLanguagesBeenSet(): boolean {
+        return _languagesURL.size > 0;
+    }
+
+    export function IsLanguageSupported(languageCode: string): boolean {
+        return _languagesURL.has(transposeLanguageFormat(languageCode));
+    }
+}


### PR DESCRIPTION
This PR is for unifying how the language mechanism works in O11 and ODC.

### What was happening
* The language mechanism was dependent of the language (JS) files to be deployed unto the server
* In ODC, that would imply having a specific app to simply deploy the files
* The team decided to use the same mechanism to O11 as it is used in ODC

### What was done
* The OS module, will now set the url for the file of each language
* The load itself, will be similar to the previous one, with the difference that the language URLs will be known before hand, instead of relying on building the url
* This also simplifies the load language API

### Test Steps
1. Go to a page with the DataGrid and change the locale.
2. The changes should be reflected in the grid

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

