### PR TITLE
ROU-4377: Invalid lines - removing attribute __osRowMetadata

### DIFF
--- a/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
@@ -376,7 +376,11 @@ namespace OSFramework.DataGrid.Grid {
 
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
         public toOSFormat(dataItem: any, stringify = true): any {
-            return this._getChangesString([dataItem], stringify);
+            return this._getChangesString(
+                /*Let's wrap the dataItem in an array, only it is not an array already*/
+                Array.isArray(dataItem) ? dataItem : [dataItem],
+                stringify
+            );
         }
 
         public trimSecondsFromDate(value: string): string {


### PR DESCRIPTION
This PR is for fixing the Invalid lines data when invoking the API. The API was returning  the metadata attribute, when it shouldn't:
![image](https://github.com/OutSystems/outsystems-datagrid/assets/10534623/89f0eca4-a971-41e3-94a8-eb9b851021dd)


### What was happening
* The code to obtain the json for invalid rows, was calling a method (`toOSFormat`) that for other changes was not occurring
* The method `toOSFormat` was wrapping the object received in an array (e.g. [dataItem]) independently on the type of dataItem

### What was done
* The method `toOSFormat` will now validate before wrapping. If it's an array, as in the case of the invalid lines, it will not wrap the data item any more.

### Test Steps
1. Access to a data grid page (e.g. `/GridReactive_Automation_InvalidLine/Validation`)
2. Make one or several lines invalid (depends on the business rules implemented, but for one, so that the line becomes invalid)
3. Invoke the api: 
```
(function(){    
    const dataGridId = OutSystems.GridAPI.GridManager.GetActiveGrid().widgetId;
    console.log(JSON.parse(JSON.parse(OutSystems.GridAPI.GridManager.GetChangesInGrid(dataGridId)).value));
})();
```
4. Validate that the attribute `__osRowMetadata` of each line is **NOT** returned.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

