### PR TITLE
ROU-4406: Issue when applying row validation to a Grid with GroupColumn

### DIFF
--- a/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
+++ b/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
@@ -24,6 +24,7 @@ namespace OSFramework.DataGrid.Enum {
         Row_InvalidStartingRowHeader = 'The starting row header is invalid.',
         Row_ListEmptyValues = 'Rows list has empty values.',
         Row_NotFound = 'Row not found.',
+        ApplyRowValidation = 'It seems you are trying to validate a GroupRow.',
         SetCurrentPage = 'An error occurred while trying to set current page.',
         SetCurrentPageServerSidePagination = 'It seems that you have server side pagination turned on. Switch it off and try again.',
         SetRowAsSelected = 'It seems that one or more of the row numbers you have providing do not exist on the current page.',

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -799,6 +799,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this._grid
                 .getColumns()
                 .forEach((column: OSFramework.DataGrid.Column.IColumn) => {
+                    const row = this._grid.provider.rows[rowNumber];
+
+                    if (row instanceof wijmo.grid.GroupRow) {
+                        throw new Error(
+                            OSFramework.DataGrid.Enum.ErrorMessages.ApplyRowValidation
+                        );
+                    }
+
                     // We need to skip Group Column since it is not a column we can validate
                     if (
                         column.columnType !==

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -799,20 +799,27 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this._grid
                 .getColumns()
                 .forEach((column: OSFramework.DataGrid.Column.IColumn) => {
-                    // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
-                    const currValue = this._grid.provider.getCellData(
-                        rowNumber,
-                        column.provider.index,
-                        column.columnType ===
-                            OSFramework.DataGrid.Enum.ColumnType.Dropdown
-                    );
-                    // Triggers the events of OnCellValueChange associated to a specific column in OS
-                    this._triggerEventsFromColumn(
-                        rowNumber,
-                        column.uniqueId,
-                        currValue,
-                        currValue
-                    );
+                    // We need to skip Group Column since it is not a column we can validate
+                    if (
+                        column.columnType !==
+                        OSFramework.DataGrid.Enum.ColumnType.Group
+                    ) {
+                        // This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
+                        const currValue = this._grid.provider.getCellData(
+                            rowNumber,
+                            column.provider.index,
+                            column.columnType ===
+                                OSFramework.DataGrid.Enum.ColumnType.Dropdown
+                        );
+
+                        // Triggers the events of OnCellValueChange associated to a specific column in OS
+                        this._triggerEventsFromColumn(
+                            rowNumber,
+                            column.uniqueId,
+                            currValue,
+                            currValue
+                        );
+                    }
                 });
         }
     }


### PR DESCRIPTION
This PR is for fix ApplyRowValidation API not working for Group Columns

### What was happening
* In validateRow method of ValidationMark feature, the getCellData return undefined since it is not possible to get the cell data from a Group Column.

### What was done
* Add an assertion to skip Group Column when validationg the row data.

### Test Steps
1. Go to a page with a Grid with mandatory columns.
2. Add a new row.
4. Run the ApplyRowValidation Client Action for the added row.
5. Check that the row's mandartory cells are set as invalid.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

