### PR TITLE
ROU-4388: Improve header's accessibility

### DIFF
--- a/src/OSFramework/DataGrid/Configuration/Grid/FlexGridConfig.ts
+++ b/src/OSFramework/DataGrid/Configuration/Grid/FlexGridConfig.ts
@@ -34,6 +34,7 @@ namespace OSFramework.DataGrid.Configuration.Grid {
             let provider: DataGrid.Types.IGridProviderConfigs = {
                 autoGenerateColumns: this.autoGenerateColumns,
                 allowMerging: 'Cells', // allow mergeCells API. This option does nothing, without the proper column config.
+                headersFocusability: wijmo.grid.HeadersFocusability.All, // by default, Row and Column headers are focusable via keyboard.
                 isReadOnly: this.allowEdit === false,
                 validateEdits: this.validateEdits,
                 showSelectedHeaders: 'All' // highlight row/column header

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -56,6 +56,7 @@ namespace OSFramework.DataGrid.Types {
     export interface IGridProviderConfigs {
         allowMerging: string;
         autoGenerateColumns: boolean;
+        headersFocusability: wijmo.grid.HeadersFocusability;
         isReadOnly: boolean;
         showSelectedHeaders: string;
         validateEdits: boolean;


### PR DESCRIPTION
This PR is for set Row and column headers to be accessible via keyboard.

### What was happening
* The Row and Column headers were not accessible via keyboard by default.

### What was done
* Set the headersFocusability property to "All" by default allowing the Row and Column headers to be accessible.

### Test Steps
1. Go to a page with a Grid with accessibility feature enabled
2. Check that it is possible to access the Row and Column headers via keyboard.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

