### PR TITLE
ROU-4413: Fix issue with Context Menu that gets duplicated Items

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -43,11 +43,12 @@ namespace Providers.DataGrid.Wijmo.Feature {
         private _addMenuItem(
             menuItem: OSFramework.DataGrid.Feature.Auxiliar.MenuItem
         ) {
-            //If already inserted to the Map return error message
+            //If already inserted to the Map return error message and exit the method
             if (this._menuItems.has(menuItem.uniqueId)) {
                 console.log(
                     '_addMenuItem - MenuItem already added to the list'
                 );
+                return;
             }
 
             //Add to the Map

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -45,9 +45,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
         ) {
             //If already inserted to the Map return error message and exit the method
             if (this._menuItems.has(menuItem.uniqueId)) {
-                console.log(
-                    '_addMenuItem - MenuItem already added to the list'
-                );
                 return;
             }
 

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -43,7 +43,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
         private _addMenuItem(
             menuItem: OSFramework.DataGrid.Feature.Auxiliar.MenuItem
         ) {
-            //If already inserted to the Map return error message and exit the method
+            //If already inserted to the Map  exit the method
             if (this._menuItems.has(menuItem.uniqueId)) {
                 return;
             }


### PR DESCRIPTION
This PR is to fix an issue that caused the Context Menu to start getting duplicated Menu Items.
This occurred when an auto-generated Data Grid got the associated data source refreshed after filtering it.

### What was happening
* Issue caused the Context Menu to start getting duplicated Menu Items:
![IssueDataGrid](https://github.com/OutSystems/outsystems-datagrid/assets/29493222/da3a476d-37ab-430e-833b-126114a51562)


### What was done
* Fix the code responsible to add menu items to take into consideration not adding duplicate items.

### Test Steps
**Test Case 1 - Auto-generated**:

1. Go to ContextMenu_Autogenerated
2. Open Context Menu
3. Filter by Date Range
4. Open Context Menu
5. Check that no duplicates are displayed

**Test Case 2 - Cols;**

1. Go ContextMenu_Cols
2. Open Context Menu
3. Filter by Date Range
4. Open Context Menu
5. Check that no duplicates are displayed


### Screenshot
![DataGridContextMenuFixed](https://github.com/OutSystems/outsystems-datagrid/assets/29493222/5580a3bf-21fb-4180-8c5b-c0236577b0f2)
s



### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

