### PR TITLE
ROU-4429: Fixing APIs `FilterByCondition` & `FilterByValue` to work with checkbox column

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -63,19 +63,33 @@ namespace Providers.DataGrid.Wijmo.Feature {
             );
         }
 
+        /**
+         * Prepares the condition value to be used in the condition filter.
+         *
+         * @private
+         * @param {OSFramework.DataGrid.Enum.ColumnType} columnType will be used to determine the type of parse to be done to the value.
+         * @param {Helper.FilterFactory.WijmoFilterConditionValue} conditionValue value to be parsed
+         * @return {*}  {Helper.FilterFactory.WijmoFilterConditionValue} value parsed according to the column type
+         * @memberof ColumnFilter
+         */
         private _getFilterConditionValue(
             columnType: OSFramework.DataGrid.Enum.ColumnType,
             conditionValue: Helper.FilterFactory.WijmoFilterConditionValue
-        ) {
+        ): Helper.FilterFactory.WijmoFilterConditionValue {
             let _formattedValue: Helper.FilterFactory.WijmoFilterConditionValue;
 
             switch (columnType) {
+                case OSFramework.DataGrid.Enum.ColumnType.Checkbox:
+                    _formattedValue = (conditionValue as string) === 'True';
+                    break;
                 case OSFramework.DataGrid.Enum.ColumnType.Number:
                     _formattedValue = parseFloat(conditionValue as string);
                     break;
                 case OSFramework.DataGrid.Enum.ColumnType.Date:
                 case OSFramework.DataGrid.Enum.ColumnType.DateTime:
-                    _formattedValue = new Date(conditionValue);
+                    _formattedValue = new Date(
+                        conditionValue as string | number
+                    );
                     break;
                 default:
                     _formattedValue = conditionValue;

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -98,6 +98,32 @@ namespace Providers.DataGrid.Wijmo.Feature {
             return _formattedValue;
         }
 
+        /**
+         * Prepares the value to be used in the filter by value.
+         *
+         * @private
+         * @param {OSFramework.DataGrid.Enum.ColumnType} columnType will be used to determine if a toLower should be done or not. Applies the toLower in columns of the type checkbox.
+         * @param {string} value value to be selected to the filter
+         * @return {*}  {string} formatted value. In case the value is null, will return ''.
+         * @memberof ColumnFilter
+         */
+        private _getFilterValue(
+            columnType: OSFramework.DataGrid.Enum.ColumnType,
+            value: string
+        ): string {
+            let _formattedValue: Helper.FilterFactory.WijmoFilterConditionValue;
+
+            switch (columnType) {
+                case OSFramework.DataGrid.Enum.ColumnType.Checkbox:
+                    _formattedValue = value.toLowerCase();
+                    break;
+                default:
+                    _formattedValue = value ?? '';
+            }
+
+            return _formattedValue;
+        }
+
         public get isGridFiltered(): boolean {
             // When filter is active/applied, check isActive property
             return (
@@ -224,8 +250,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 // eg.: {Brazil: true, Portugal: true}. So let's transform this to the desired input
                 columnFilter.showValues = values
                     .map((val) => {
-                        if (val === null) return '';
-                        return val;
+                        return this._getFilterValue(column.columnType, val);
                     })
                     .reduce((obj, cur) => {
                         return { ...obj, [cur]: true };

--- a/src/Providers/DataGrid/Wijmo/Helper/FilterFactory.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/FilterFactory.ts
@@ -29,7 +29,7 @@ namespace Providers.DataGrid.Wijmo.Helper.FilterFactory {
     /**
      * The type below represents the wijmo filter condition value
      */
-    export type WijmoFilterConditionValue = number | string | Date;
+    export type WijmoFilterConditionValue = number | string | Date | boolean;
 
     /**
      * Function that creates a condition for for the filter to send to OutSystems.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "amd",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": false,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
This PR is for fixing APIs `FilterByCondition` & `FilterByValue` that were not working with the checkbox column.

### What was happening
* When using the `FilterByCondition` API to filter CheckboxColumn, the result is empty even if there are some values in the database that match the filter.

### What was done
* In the private method `_getFilterConditionValue` added a new check for the checkbox column, where the `_formattedValue` is equal to the string 'True'  of the platform. -> **This fixes the `FilterByCondition` API**
* Created a new private method `_getFilterValue` that format the value to be compared, it encapsulates the previous behavior and adds a special check for checkbox columns. -> -> **This fixes the `FilterByValue` API**

### Test Steps
1. Open sample page
2. Use the API `FilterByCondition`, to filter the column checkbox
3. See if there are results corresponding to the scenario tested (e.g. true)

### Screenshots
![datagrid-filter-fixed](https://github.com/OutSystems/outsystems-datagrid/assets/10534623/3ad304f0-da83-454f-9bcd-a7c59fc2a1f6)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

