### PR TITLE
ROU-4304: Revert empty strings being converted in undefined

### DIFF
--- a/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
@@ -18,7 +18,7 @@ namespace OSFramework.DataGrid.Grid {
      * Responsible for parsing string fields to its correct data type
      *
      * @param data A string of the JSON data object
-     * @example OS Date fields is send as strings, and we should parse it to Date, the is done for Datetime fields.
+     * @example OS Date fields are sent as strings, and we should parse it to Date, the same is done for Datetime fields.
      */
     function ToJSONFormat(
         data: string,
@@ -69,7 +69,16 @@ namespace OSFramework.DataGrid.Grid {
                         (type === 'Date' || type === 'DateTime')
                     ) {
                         return new Date(+m[1], +m[2] - 1, +m[3]);
-                    } else if (val === '') {
+                    }
+                    // if it is an empty string and the type is Date/DateTime, we want to convert it to undefined
+                    // if it is an empty string and the type is null or undefined, we don't know if it is a Date/DateTime or not, so we convert it to undefined any way
+                    else if (
+                        val === '' &&
+                        (type === 'Date' ||
+                            type === 'DateTime' ||
+                            type === null ||
+                            type === undefined)
+                    ) {
                         return undefined;
                     }
                     return val;


### PR DESCRIPTION
This PR is for revert empty strings being converted in undefined.

### What was happening
* OS Date/DateTime fields are sent as strings, and we should parse it to the correct data type. When they are empty strings, we convert it to undefined.
* The problem is that we are doing it for all data that are empty strings, which is not necessary

### What was done
* Changed the ToJSONFormat function of AbstractDataSource file to only convert to only convert empty string in undefined in two cases:
    * When it is Date or DateTime columns data
    * When it is an unknown data type, because it can or cannot be Date/DateTime, so we convert it to avoid errors.

### Test Steps
1. Go to a page witha Grid to the page containing some data with empty values in Text, Date and DateTime columns.
2. Call the GetRowData Client Action for the desired RowNumber
3. Check that the Text Column data are returned as empty, but the Date and DateTime data are undefined.


### Screenshots
Before:
![image](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/c2715c3c-d5b1-428f-a465-ba178397c934)
After:
![image](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/a98065e5-f51a-4f69-9b46-bbfaa2b26af0)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

