### PR TITLE
ROU-4414: Review Context Menu lifecycle for auto-generated Grids

### DIFF
--- a/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
@@ -156,7 +156,7 @@ namespace OSFramework.DataGrid.Grid {
                     hasColumns = newColumns.every((column) => {
                         return columns.indexOf(`${source}.${column}`) !== -1;
                     });
-                } 
+                }
                 // If not an object, we assume it is a string, meaning that the column binding is the "source" itself
                 // So we check if this is a new column
                 else {

--- a/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractGrid.ts
@@ -149,10 +149,19 @@ namespace OSFramework.DataGrid.Grid {
                 (col) => col.config.binding
             );
             return Object.keys(metadata).some((source) => {
-                const newColumns = Object.keys(metadata[source]);
-                hasColumns = newColumns.every((column) => {
-                    return columns.indexOf(`${source}.${column}`) !== -1;
-                });
+                const isObject = typeof metadata[source] === 'object';
+                // If it is an object, let's iterate into the keys to check if there are new columns
+                if (isObject) {
+                    const newColumns = Object.keys(metadata[source]);
+                    hasColumns = newColumns.every((column) => {
+                        return columns.indexOf(`${source}.${column}`) !== -1;
+                    });
+                } 
+                // If not an object, we assume it is a string, meaning that the column binding is the "source" itself
+                // So we check if this is a new column
+                else {
+                    hasColumns = columns.indexOf(source) !== -1;
+                }
 
                 return !hasColumns;
             });


### PR DESCRIPTION
This PR is for...

[Sample page](url)

### What was happening
* In autogenerated Grids, we were not covering cases when the column binding is different from the type "Entity.Field" when checking for new columns in `checkForNewColumns` function in `AbstractGrid`.
* Because of that, when the Grid has a binding in the format "Field" instead of "Entity.Field" for example, and the data source is refreshed, it accuses to have new columns added and the initialized events run again without need.

### What was done
* Fix `checkForNewColumns` function in `AbstractGrid` to cover these missing cases.
* Now, we check if the `metadata[source]` is an object or not. If it is the binding is in the format "Entity.Field", otherwise it is in the format "Field".
`
### Test Steps
1. Go to a page with an autogenerated Grid.
2. The data source should have bindings in the format "Field" and "Entity.Field"
3. Refresh the data source 
4. Check that the console does not have "Remove column ..." logs.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

