### PR TITLE
ROU-4460: Critical issue on version 2.12.0 on Grouped Columns

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/GroupColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/GroupColumn.ts
@@ -56,8 +56,7 @@ namespace Providers.DataGrid.Wijmo.Column {
          * Gets binding on which the group will be collapsed to
          */
         private _getCollapsedToBinding(columnBinding: string): string {
-            if (columnBinding === undefined || columnBinding === '')
-                return undefined;
+            if (columnBinding === undefined || columnBinding === '') return '';
 
             const col = this.grid.getColumn(columnBinding);
             let hasError = false;
@@ -79,7 +78,7 @@ namespace Providers.DataGrid.Wijmo.Column {
                     }. ${'\n'}  Please drag-and-drop the column inside the group placeholder or pick one of the columns inside it.`
                 );
                 //No collapseTo
-                return undefined;
+                return '';
             }
         }
 


### PR DESCRIPTION
This PR is for fix critical issue on version 2.12.0 on Grouped Columns

### What was happening
* Due to a Wijmo breaking change the collapseTo property is not accepting undefined anymore, just "" or []

### What was done
* In _getCollapsedToBinding, instead of returning undefined, we are now returning an empty string.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

