### PR TITLE
ROU-4460: Critical issue on version 2.12.0 on Grouped Columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "OutSystems Data Grid for Reactive Web",
   "author": "UI Components Team",
   "license": "BSD-3-Clause",

--- a/src/OSFramework/DataGrid/Constants.ts
+++ b/src/OSFramework/DataGrid/Constants.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.DataGrid.Constants {
     /* OutSystems Data Grid Version */
-    export const OSDataGridVersion = '2.12.0';
+    export const OSDataGridVersion = '2.12.1';
 }

--- a/src/Providers/DataGrid/Wijmo/Columns/GroupColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/GroupColumn.ts
@@ -56,8 +56,7 @@ namespace Providers.DataGrid.Wijmo.Column {
          * Gets binding on which the group will be collapsed to
          */
         private _getCollapsedToBinding(columnBinding: string): string {
-            if (columnBinding === undefined || columnBinding === '')
-                return undefined;
+            if (columnBinding === undefined || columnBinding === '') return '';
 
             const col = this.grid.getColumn(columnBinding);
             let hasError = false;
@@ -79,7 +78,7 @@ namespace Providers.DataGrid.Wijmo.Column {
                     }. ${'\n'}  Please drag-and-drop the column inside the group placeholder or pick one of the columns inside it.`
                 );
                 //No collapseTo
-                return undefined;
+                return '';
             }
         }
 


### PR DESCRIPTION
This PR is for fix critical issue on version 2.12.0 on Grouped Columns

### What was happening
* Due to a breaking change of Wijmo's library, the collapseTo does not accept undefined anymore, triggering an error.

### What was done
* In GroupColumn's _getCollapsedToBinding method, changed the return to an empty string instead of undefined.

### Test Steps
1. In GroupColumn _getCollapsedToBinding method, changed to return an empty string instead of undefined,

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

