### PR TITLE
ROU-4481: Implement workarounds for Wijmo's issues for frozen columns and Backspace/Delete keys

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFreeze.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFreeze.ts
@@ -11,6 +11,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this._grid = grid;
         }
 
+        // Method added to fix the issue when frozen columns are resized to their maximum width and it is not possible to resized it again.
         private _afterResizeColumn(
             grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
@@ -26,6 +27,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     otherfrozenColumnsWidth += col.width;
                 }
             });
+            // Checks if the column was resized to the maximum width and resizes it in 10 pixels less than the max width
             if (frozenColumnsWidth >= grid.clientSize.width) {
                 grid.columns[e.col].size =
                     grid.clientSize.width - otherfrozenColumnsWidth - 10;

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFreeze.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFreeze.ts
@@ -11,12 +11,35 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this._grid = grid;
         }
 
+        private _afterResizeColumn(
+            grid: wijmo.grid.FlexGrid,
+            e: wijmo.grid.CellRangeEventArgs
+        ): void {
+            let frozenColumnswidht = 0;
+            let otherfrozenColumnswidht = 0;
+            let frozenColumns = grid.columns.filter(
+                (col) => col.index < grid.frozenColumns
+            );
+            frozenColumns.forEach((col, index) => {
+                frozenColumnswidht += col.width;
+                if (index !== e.col) {
+                    otherfrozenColumnswidht += col.width;
+                }
+            });
+            if (frozenColumnswidht >= grid.clientSize.width) {
+                grid.columns[e.col].size =
+                    grid.clientSize.width - otherfrozenColumnswidht - 10;
+            }
+        }
+
         public get isFrozen(): boolean {
             return this._grid.provider.frozenColumns !== 0;
         }
 
         public build(): void {
-            // Implementing interface
+            this._grid.provider.resizedColumn.addHandler(
+                this._afterResizeColumn
+            );
         }
 
         public byActiveSelection(): void {

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFreeze.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFreeze.ts
@@ -15,20 +15,20 @@ namespace Providers.DataGrid.Wijmo.Feature {
             grid: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
-            let frozenColumnswidht = 0;
-            let otherfrozenColumnswidht = 0;
-            let frozenColumns = grid.columns.filter(
+            let frozenColumnsWidth = 0;
+            let otherfrozenColumnsWidth = 0;
+            const frozenColumns = grid.columns.filter(
                 (col) => col.index < grid.frozenColumns
             );
             frozenColumns.forEach((col, index) => {
-                frozenColumnswidht += col.width;
+                frozenColumnsWidth += col.width;
                 if (index !== e.col) {
-                    otherfrozenColumnswidht += col.width;
+                    otherfrozenColumnsWidth += col.width;
                 }
             });
-            if (frozenColumnswidht >= grid.clientSize.width) {
+            if (frozenColumnsWidth >= grid.clientSize.width) {
                 grid.columns[e.col].size =
-                    grid.clientSize.width - otherfrozenColumnswidht - 10;
+                    grid.clientSize.width - otherfrozenColumnsWidth - 10;
             }
         }
 

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -51,8 +51,12 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
             // when a delete event occurs, s.getCellData() always returns an empty string
             // because of that, we need to verify if a delete event occured and get the right current value
-            if (!!e.data && !!e.data.key && e.data.key === 'Delete') {
-                currentValue = e.data.target.textContent;
+            if (
+                !!e.data &&
+                !!e.data.key &&
+                (e.data.key === 'Delete' || e.data.key === 'Backspace')
+            ) {
+                currentValue = s.activeCell.textContent;
             } else {
                 currentValue = s.getCellData(e.row, e.col, true) ?? '';
             }


### PR DESCRIPTION
This PR is for Implement workarounds for Wijmo's issues for frozen columns and Backspace/Delete keys

### What was happening
* When using the BackSpace/Delete keys the OnCellValueChange event was not triggering
* When a frozen column was resized to its maximum possible width, it was not possible to resize it again.

### What was done
* Now, if the Delete or BackSpace keys are used, we store the s.activeCell.textContent as the currentValue in _cellEditBeforeEndingHandler method of ValidationMark.
* Added the _afterResizeColumn method to the ColumnFreeze, which checks if the column was resized to the maximum width and resizes it in 10 pixels less than the max.

### Test Steps
#### Test 1
1. Go to a test page
2. Use Delete or BackSpace key to erase the cell value
3. Check that the OnCellValueChange event was triggered.

#### Test 2
1. Go to a test page with a Grid with a frozen column
2. Resize the column until its maximum possible width
3. Check that it is still possible to resize it.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

