### PR TITLE
ROU-4476 - Fixed wrap styles

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/Styling.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Styling.ts
@@ -121,6 +121,11 @@ namespace Providers.DataGrid.Wijmo.Feature {
         ): void {
             // validate if column exists
             const column = this._grid.getColumn(columnID);
+            // add css class to make exception for the wrap styles
+            wijmo.addClass(
+                this._grid.provider.hostElement,
+                'has-column-word-wrap'
+            );
             if (column) {
                 column.provider.wordWrap = value;
                 if (dynamicHeight) {

--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -419,6 +419,14 @@
     background-color: var(--color-neutral-3);
 }
 
+.has-column-word-wrap .wj-cell {
+    padding: 8px;
+}
+
+.has-column-word-wrap .wj-colheaders > .wj-row > .wj-cell::before {
+    display: none;
+}
+
 /**** DATAGRID STYLE CLASSES ****/
 
 * {


### PR DESCRIPTION
This PR is for fixing the cells and headers when using the SetColumnWordWrap API.

Now a class is added on the host element, so that the CSS exceptions have no impact in other use-cases.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

