### PR TITLE
ROU-4182: Improve Image column CSS

### DIFF
--- a/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigAction.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigAction.ts
@@ -15,5 +15,16 @@ namespace OSFramework.DataGrid.Configuration.Column {
             super(config);
             this.actionColumnElementType = extraConfig.actionColumnElementType;
         }
+
+        public getProviderConfig(): DataGrid.Types.IColumnProviderConfigs {
+            const config = super.getProviderConfig();
+            if (
+                this.actionColumnElementType ===
+                DataGrid.Enum.CellTemplateElementType.Button
+            )
+                config.cssClassAll = 'has-image-or-button';
+
+            return config;
+        }
     }
 }

--- a/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigImage.ts
+++ b/src/OSFramework/DataGrid/Configuration/Column/ColumnConfigImage.ts
@@ -17,5 +17,12 @@ namespace OSFramework.DataGrid.Configuration.Column {
             super(config);
             this.altText = extraConfig.altText;
         }
+
+        public getProviderConfig(): DataGrid.Types.IColumnProviderConfigs {
+            const config = super.getProviderConfig();
+            config.cssClassAll = 'has-image-or-button';
+
+            return config;
+        }
     }
 }

--- a/src/OSFramework/DataGrid/Types/index.ts
+++ b/src/OSFramework/DataGrid/Types/index.ts
@@ -78,6 +78,7 @@ namespace OSFramework.DataGrid.Types {
         allowSorting: boolean;
         cellTemplate?: wijmo.grid.ICellTemplateFunction;
         collapseTo?: string;
+        cssClassAll?: string;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         dataMap?: any;
         dataMapEditor?: wijmo.grid.DataMapEditor;

--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -1152,9 +1152,9 @@
     position: absolute;
 }
 
-/**** BUTTON STYLE CLASSES ****/
+/**** BUTTON/IMAGE STYLE CLASSES ****/
 
-.wj-cell:has(button.wj-cell-maker) {
+.wj-cell.has-image-or-button:not(.wj-header) {
     padding-top: 10px !important;
     padding-bottom: 10px !important;
 }


### PR DESCRIPTION
- Improved code for Action column with button so it works in Firefox as well

This PR is for fix Image Column cell css

### What was happening
* The image was not centered in the cell when the Image column was rendered
* We were using the :has to apply CSS to the button of the Action Column which is not supported in Firefox. 

### What was done
* Created the has-image-or-button class to be applied in Action column with buttons and Image Columns.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

