### PR TITLE
ROU-4439: Issue with dropdown column when deleting multiple cells

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -164,14 +164,15 @@ namespace Providers.DataGrid.Wijmo.Column {
                 rowNumber,
                 this.provider.index
             );
+            const currentSel = this.grid.provider.selection;
 
             // check if current parent cell has an undo action on undo stack
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const existingUndoAction: any =
                 this.grid.features.undoStack.stack._stack.find(
                     (data: GridEditAction) =>
-                        data.col === column.provider.index &&
-                        data.row === rowNumber
+                        data.col === currentSel.leftCol &&
+                        data.row === currentSel.topRow
                 );
 
             if (existingUndoAction) {

--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -166,7 +166,7 @@ namespace Providers.DataGrid.Wijmo.Column {
             );
             const currentSel = this.grid.provider.selection;
 
-            // check if current parent cell has an undo action on undo stack
+            // check if the first selected parent cell has an undo action on undo stack
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const existingUndoAction: any =
                 this.grid.features.undoStack.stack._stack.find(


### PR DESCRIPTION
This PR is to fix the issue with the dropdown column when deleting multiple cells and undoing the action.

### What was happening
* When deleting multiple cells of dropdown cells with dropdown dependency and undoing it, not all the child cells were being restored to their previous value. 
* This was happening because not all the undo actions were being registered as children of the first undo action.

### What was done
* Instead of trying to find the action related to the parent dropdown action for each child in the undo stack, we now search for the action related to the first parent cell selected for all the child dropdown actions.

### Test Steps
1. Go to a test page that contains a Grid implemented with dropdown columns with dependency
2. Select multiple cells of the parent dropdown column
3. Press Delete
4. Press Ctrl+Z to undo
5. Check that all the cells from the parent and child dropdown return to their original values.


### Screenshots
![dropdownDependencyFix](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/05efa2ae-9455-45cf-bec8-16a5ec75fe6d)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

