### PR TITLE
ROU-4519: Issue with dropdown column with dependency triggering OnCellValueChange event twice

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -160,13 +160,14 @@ namespace Providers.DataGrid.Wijmo.Column {
                     this.provider.index,
                     false
                 ) ?? '';
-            
+
             // if the child dropdown value is already empty, we don't want register the undo action and trigger cell value change event again
             if (column && currentValue !== '') {
                 // get original value of the child cell
                 const originalValue = this.grid.features.dirtyMark.getOldValue(
                     rowNumber,
-                    this.grid.getColumnByIndex(this.provider.index).config.binding
+                    this.grid.getColumnByIndex(this.provider.index).config
+                        .binding
                 );
 
                 const cellRange = new wijmo.grid.CellRange(
@@ -200,9 +201,7 @@ namespace Providers.DataGrid.Wijmo.Column {
                         ) ?? false;
 
                     // only add child undo action if it doesn't already exist. we don't want duplicated actions
-                    if (
-                        existingEditActionForColRow === false
-                    ) {
+                    if (existingEditActionForColRow === false) {
                         // add new child action into existing parent action in order
                         existingUndoAction.addChildAction(
                             new GridEditAction(

--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -160,66 +160,81 @@ namespace Providers.DataGrid.Wijmo.Column {
                     this.provider.index,
                     false
                 ) ?? '';
-            const cellRange = new wijmo.grid.CellRange(
-                rowNumber,
-                this.provider.index
-            );
-            const currentSel = this.grid.provider.selection;
-
-            // check if the first selected parent cell has an undo action on undo stack
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const existingUndoAction: any =
-                this.grid.features.undoStack.stack._stack.find(
-                    (data: GridEditAction) =>
-                        data.col === currentSel.leftCol &&
-                        data.row === currentSel.topRow
+            
+            // if the child dropdown value is already empty, we don't want register the undo action and trigger cell value change event again
+            if (column && currentValue !== '') {
+                // get original value of the child cell
+                const originalValue = this.grid.features.dirtyMark.getOldValue(
+                    rowNumber,
+                    this.grid.getColumnByIndex(this.provider.index).config.binding
                 );
 
-            if (existingUndoAction) {
-                // check if current child cell has an undo action on undo stack
-                const existingEditActionForColRow =
-                    existingUndoAction?._actions?.find(
-                        (action: GridEditAction) =>
-                            action.col === this.provider.index &&
-                            action.row === rowNumber
-                    ) ?? false;
+                const cellRange = new wijmo.grid.CellRange(
+                    rowNumber,
+                    this.provider.index
+                );
+                const currentSel = this.grid.provider.selection;
 
-                // only add child undo action if it doesn't already exist. we don't want duplicated actions
-                if (existingEditActionForColRow === false) {
-                    // add new child action into existing parent action in order
-                    existingUndoAction.addChildAction(
-                        new GridEditAction(
-                            this.grid,
-                            new wijmo.grid.CellRangeEventArgs(
-                                this.grid.provider.cells,
-                                cellRange
-                            )
-                        )
+                // filter the parent cell has an undo actions on undo stack
+                const filteredUndoAction: wijmo.undo.UndoableAction[] =
+                    this.grid.features.undoStack.stack._stack.filter(
+                        (data: GridEditAction) =>
+                            data.col === currentSel.leftCol &&
+                            data.row === currentSel.topRow
                     );
+
+                // get the lastest undo action filtered if any
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const existingUndoAction: any =
+                    filteredUndoAction.length > 0
+                        ? filteredUndoAction[filteredUndoAction.length - 1]
+                        : undefined;
+
+                if (existingUndoAction) {
+                    // check if current child cell has an undo action on undo stack
+                    const existingEditActionForColRow =
+                        existingUndoAction?._actions?.find(
+                            (action: GridEditAction) =>
+                                action.col === this.provider.index &&
+                                action.row === rowNumber
+                        ) ?? false;
+
+                    // only add child undo action if it doesn't already exist. we don't want duplicated actions
+                    if (
+                        existingEditActionForColRow === false
+                    ) {
+                        // add new child action into existing parent action in order
+                        existingUndoAction.addChildAction(
+                            new GridEditAction(
+                                this.grid,
+                                new wijmo.grid.CellRangeEventArgs(
+                                    this.grid.provider.cells,
+                                    cellRange
+                                )
+                            )
+                        );
+                    }
                 }
-            }
 
-            // always clear the child cell when the parent changes
-            this.grid.provider.setCellData(
-                rowNumber,
-                this.provider.index,
-                '',
-                true
-            );
+                // always clear the child cell when the parent changes
+                this.grid.provider.setCellData(
+                    rowNumber,
+                    this.provider.index,
+                    '',
+                    true
+                );
 
-            this.grid.features.validationMark.validateCell(
-                rowNumber,
-                this,
-                true
-            );
+                this.grid.features.validationMark.validateCell(
+                    rowNumber,
+                    this,
+                    false
+                );
 
-            // trigger cell value change event
-            if (column) {
                 this.columnEvents.trigger(
                     OSFramework.DataGrid.Event.Column.ColumnEventType
                         .OnCellValueChange,
                     '',
-                    currentValue,
+                    originalValue,
                     rowNumber
                 );
             }

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -790,6 +790,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     currValue,
                     currValue
                 );
+            } else {
+                this._setCellStatus(column, rowNumber, currValue);
             }
         }
 


### PR DESCRIPTION
This PR is for fix the dropdown child triggering the OnCellValueChange more than once.


### What was happening
- When the Grid has a dropdown column with dependency, the OnCellValueChange event was triggered twice when the parent cell value changed.
- 

### What was done
- Add validation to check if currentValue is different than empty when adding the child undo action and triggering the OnCellValueChange event.
   - If the currentValue is already empty, we don't need to set the cell value to empty again and add it to the undo stack.
- Change the way we get the last parent cell's undo action on the undo stack.
   - We want to ensure that the child's undo action is added to the last parent's undo action in the undo stack. 
- Disabled the trigger in the validateCell method to trigger the OnCellValueChange event just once.
   - The onCellValueChange is already explicitly being triggered in the _parentCellValueChangeHandler, We don't need to do this twice.
- Trigger the OnCellValueChange with the original value instead of currentValue.
   - The OnCellValueChange event must return the original value and not the previous cell value.
- Added an else statement in ValidationMark's validateCell method to validate the cell event even when not triggering the columns event.

### Test Steps
1. Go to a page containing a Grid with dropdown dependency.
2. Change the parent cell value
3. Check that the child's OnCellValueChange is triggered just once for the child dropdown.
4. Press Ctrl+Z to undo
5. Check that the child's OnCellValueChange is triggered just once for the child dropdown.

### Screenshots
Before the changes:
![dropdownDependencyIssue](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/08dea6ab-2823-454c-a4ef-cd7a38d58d36)

After the changes: 
![dropdownDependencyIssueSolved](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/09dfe099-2a3b-4ad4-a1a4-50a545612621)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

