### PR TITLE
ROU-4571: Set custom tooltip on ColumnGroup

### DIFF
--- a/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
+++ b/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
@@ -27,6 +27,7 @@ namespace OSFramework.DataGrid.Enum {
         ApplyRowValidation = 'It seems you are trying to validate a GroupRow.',
         SetCurrentPage = 'An error occurred while trying to set current page.',
         SetCurrentPageServerSidePagination = 'It seems that you have server side pagination turned on. Switch it off and try again.',
+        SetColumnHeaderTooltip = 'You are trying to use the setGroupHeaderTooltip in a cell that is not a Column Group header.',
         SetRowAsSelected = 'It seems that one or more of the row numbers you have providing do not exist on the current page.',
         SuccessMessage = 'Success',
         UnableToAddRow = 'Unable to add row. Please use ArrangeData action to serialize your data.',

--- a/src/OSFramework/DataGrid/Feature/ExposedFeatures.ts
+++ b/src/OSFramework/DataGrid/Feature/ExposedFeatures.ts
@@ -28,7 +28,7 @@ namespace OSFramework.DataGrid.Feature {
         public sort: IColumnSort;
         public styling: IStyling;
         public tabNavigation: ITabNavigation;
-        public toolTip: ITooltip;
+        public tooltip: ITooltip;
         public undoStack: IUndoStack;
         public validationMark: IValidationMark;
         public view: IView;

--- a/src/OSFramework/DataGrid/Feature/ExposedFeatures.ts
+++ b/src/OSFramework/DataGrid/Feature/ExposedFeatures.ts
@@ -28,6 +28,7 @@ namespace OSFramework.DataGrid.Feature {
         public sort: IColumnSort;
         public styling: IStyling;
         public tabNavigation: ITabNavigation;
+        public toolTip: ITooltip;
         public undoStack: IUndoStack;
         public validationMark: IValidationMark;
         public view: IView;

--- a/src/OSFramework/DataGrid/Feature/ITooltip.ts
+++ b/src/OSFramework/DataGrid/Feature/ITooltip.ts
@@ -4,11 +4,11 @@ namespace OSFramework.DataGrid.Feature {
         /**
          * Set the Column Group header tooltip content.
          * @param {HTMLElement} cell
-         * @param {string} toolTipContent
+         * @param {string} tooltipContent
          */
         setColumnGroupHeaderTooltip(
             cell: HTMLElement,
-            toolTipContent: string
+            tooltipContent: string
         ): void;
     }
 }

--- a/src/OSFramework/DataGrid/Feature/ITooltip.ts
+++ b/src/OSFramework/DataGrid/Feature/ITooltip.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.DataGrid.Feature {
+    export interface ITooltip {
+        /**
+         * Set the Column Group header tooltip content.
+         * @param {HTMLElement} cell
+         * @param {string} toolTipContent
+         */
+        setColumnGroupHeaderTooltip(
+            cell: HTMLElement,
+            toolTipContent: string
+        ): void;
+    }
+}

--- a/src/OSFramework/DataGrid/Helper/GlobalEnum.ts
+++ b/src/OSFramework/DataGrid/Helper/GlobalEnum.ts
@@ -1,0 +1,11 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace OSFramework.DataGrid.Helper.GlobalEnum {
+    export enum HTMLAttributes {
+        Class = 'class'
+    }
+
+    export enum HTMLEvent {
+        MouseOver = 'mouseover',
+        MouseOut = 'mouseout'
+    }
+}

--- a/src/Providers/DataGrid/Wijmo/Features/FeatureBuilder.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/FeatureBuilder.ts
@@ -206,8 +206,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
             return this;
         }
 
-        private _makeToolTip(): FeatureBuilder {
-            this._features.toolTip = this._makeItem(ToolTip);
+        private _makeTooltip(): FeatureBuilder {
+            this._features.tooltip = this._makeItem(Tooltip);
             return this;
         }
 
@@ -234,7 +234,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 ._makeGroupPanel(config.groupPanelId)
                 ._makeCellData()
                 ._makeCellStyle()
-                ._makeToolTip()
+                ._makeTooltip()
                 ._makePagination(config.rowsPerPage)
                 ._makeSort(config.allowColumnSort)
                 ._makeGridReorder(config.allowColumnReorder)

--- a/src/Providers/DataGrid/Wijmo/Features/FeatureBuilder.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/FeatureBuilder.ts
@@ -207,7 +207,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         private _makeToolTip(): FeatureBuilder {
-            this._makeItem(ToolTip);
+            this._features.toolTip = this._makeItem(ToolTip);
             return this;
         }
 

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -192,7 +192,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
         public setColumnGroupHeaderTooltip(
             cell: HTMLElement,
             toolTipContent: string
-        ) {
+        ): void {
             if (
                 cell.classList.contains(Helper.Constants.CssClasses.ColumnGroup)
             ) {

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -38,6 +38,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     );
                 }
             } else if (cellType === wijmo.grid.CellType.ColumnHeader) {
+                // If the Column Header is from a Group Column, we need to use a different approach that the regular header
                 if (
                     _currTarget.classList.contains(
                         Helper.Constants.CssClasses.ColumnGroup
@@ -101,7 +102,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         private _setColumnGroupHeaderTooltip(cell: HTMLElement) {
+            // Do nothing if a tooltip is already set for this column
             if (this._toolTip.getTooltip(cell)) return;
+            // Otherwise, the tooltip will be the header text
             const headerTooltip = OSFramework.DataGrid.Helper.Sanitize(
                 cell.innerText
             );

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Providers.DataGrid.Wijmo.Feature {
-    export class ToolTip
+    export class Tooltip
         implements
             OSFramework.DataGrid.Feature.ITooltip,
             OSFramework.DataGrid.Interface.IBuilder,
@@ -11,11 +11,11 @@ namespace Providers.DataGrid.Wijmo.Feature {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         private _eventMouseOut: any;
         private _grid: Grid.IGridWijmo;
-        private _toolTip: wijmo.Tooltip;
+        private _tooltip: wijmo.Tooltip;
 
         constructor(grid: Grid.IGridWijmo) {
             this._grid = grid;
-            this._toolTip = new wijmo.Tooltip();
+            this._tooltip = new wijmo.Tooltip();
             this._eventMouseEnter = this._onMouseEnter.bind(this);
             this._eventMouseOut = this._onMouseOut.bind(this);
         }
@@ -31,7 +31,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
             ) {
                 //Check if we do have data available, for instance while using filters that make the Grid without results
                 if (this._grid.provider.rows.length > 0) {
-                    this._setCellToolTip(
+                    this._setCellTooltip(
                         _currTarget,
                         ht.getColumn().binding,
                         ht.row
@@ -43,17 +43,19 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     _currTarget.classList.contains(
                         Helper.Constants.CssClasses.ColumnGroup
                     )
-                )
+                ) {
                     this._setColumnGroupHeaderTooltip(_currTarget);
-                else this._setHeaderTooltip(_currTarget, ht);
+                } else {
+                    this._setHeaderTooltip(_currTarget, ht);
+                }
             }
         }
 
         private _onMouseOut(): void {
-            this._toolTip.hide();
+            this._tooltip.hide();
         }
 
-        private _setCellToolTip(
+        private _setCellTooltip(
             cell: HTMLElement,
             binding: string,
             row: number
@@ -74,7 +76,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
             }
 
             //Make sure to apply the correct tooltipClass
-            this._toolTipClass(isInvalid);
+            this._tooltipClass(isInvalid);
 
             //If the cell is valid
             if (isInvalid === false) {
@@ -84,14 +86,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     sanitizedValue !== ''
                 ) {
                     //JS asserts the previous declaration as true when they are equal
-                    this._toolTip.show(cell, sanitizedValue); // show tooltip if text is overflow/hidden
+                    this._tooltip.show(cell, sanitizedValue); // show tooltip if text is overflow/hidden
                 } else {
-                    this._toolTip.hide();
+                    this._tooltip.hide();
                 }
             }
             //Otherwise (If the cell is invalid)
             else {
-                this._toolTip.show(
+                this._tooltip.show(
                     cell,
                     this._grid.features.validationMark.errorMessage(
                         row,
@@ -103,14 +105,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
         private _setColumnGroupHeaderTooltip(cell: HTMLElement) {
             // Do nothing if a tooltip is already set for this column
-            if (this._toolTip.getTooltip(cell)) return;
+            if (this._tooltip.getTooltip(cell)) return;
             // Otherwise, the tooltip will be the header text
             const headerTooltip = OSFramework.DataGrid.Helper.Sanitize(
                 cell.innerText
             );
 
-            this._toolTipClass(false);
-            this._toolTip.show(cell, headerTooltip);
+            this._tooltipClass(false);
+            this._tooltip.show(cell, headerTooltip);
         }
 
         private _setHeaderTooltip(
@@ -142,22 +144,23 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 headerTooltip = sanitizedValue;
             }
 
-            this._toolTipClass(false);
-            this._toolTip.show(cell, headerTooltip);
+            this._tooltipClass(false);
+            this._tooltip.show(cell, headerTooltip);
         }
 
-        private _toolTipClass(isInvalid: boolean): void {
-            if (isInvalid === true)
-                this._toolTip.cssClass =
+        private _tooltipClass(isInvalid: boolean): void {
+            if (isInvalid === true) {
+                this._tooltip.cssClass =
                     Helper.Constants.CssClasses.TooltipErrorValidation;
-            else {
-                this._toolTip.cssClass = '';
+            } else {
+                this._tooltip.cssClass = '';
 
                 // Implementation of the workaround provided by Wijmo related to ROU-4207 issue.
                 // To be removed after Wijmo fix.
                 if (wijmo.Tooltip._eTip)
                     wijmo.Tooltip._eTip.setAttribute(
-                        Helper.Constants.HTMLAttributes.Class,
+                        OSFramework.DataGrid.Helper.GlobalEnum.HTMLAttributes
+                            .Class,
                         Helper.Constants.CssClasses.Tooltip
                     );
             }
@@ -167,20 +170,24 @@ namespace Providers.DataGrid.Wijmo.Feature {
             this._grid.provider.formatItem.addHandler(
                 (s: wijmo.grid.FlexGrid, e: wijmo.grid.FormatItemEventArgs) => {
                     e.cell.removeEventListener(
-                        Helper.Constants.HTMLEvent.MouseOver,
+                        OSFramework.DataGrid.Helper.GlobalEnum.HTMLEvent
+                            .MouseOver,
                         this._eventMouseEnter
                     );
                     e.cell.addEventListener(
-                        Helper.Constants.HTMLEvent.MouseOver,
+                        OSFramework.DataGrid.Helper.GlobalEnum.HTMLEvent
+                            .MouseOver,
                         this._eventMouseEnter
                     );
 
                     e.cell.removeEventListener(
-                        Helper.Constants.HTMLEvent.MouseOut,
+                        OSFramework.DataGrid.Helper.GlobalEnum.HTMLEvent
+                            .MouseOut,
                         this._eventMouseOut
                     );
                     e.cell.addEventListener(
-                        Helper.Constants.HTMLEvent.MouseOut,
+                        OSFramework.DataGrid.Helper.GlobalEnum.HTMLEvent
+                            .MouseOut,
                         this._eventMouseOut
                     );
                 }
@@ -188,18 +195,18 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         public dispose(): void {
-            this._toolTip.dispose();
-            this._toolTip = undefined;
+            this._tooltip.dispose();
+            this._tooltip = undefined;
         }
 
         public setColumnGroupHeaderTooltip(
             cell: HTMLElement,
-            toolTipContent: string
+            tooltipContent: string
         ): void {
             if (
                 cell.classList.contains(Helper.Constants.CssClasses.ColumnGroup)
             ) {
-                this._toolTip.setTooltip(cell, toolTipContent);
+                this._tooltip.setTooltip(cell, tooltipContent);
             } else {
                 console.warn(
                     OSFramework.DataGrid.Enum.ErrorMessages

--- a/src/Providers/DataGrid/Wijmo/Helper/Constants.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/Constants.ts
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+namespace Providers.DataGrid.Wijmo.Helper.Constants {
+    export enum CssClasses {
+        CellClass = 'div.dg-cell',
+        ColumnGroup = 'wj-colgroup',
+        Tooltip = 'wj-tooltip',
+        TooltipErrorValidation = 'errorValidation'
+    }
+
+    export enum HTMLAttributes {
+        Class = 'class'
+    }
+
+    export enum HTMLEvent {
+        MouseOver = 'mouseover',
+        MouseOut = 'mouseout'
+    }
+}

--- a/src/Providers/DataGrid/Wijmo/Helper/Constants.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/Constants.ts
@@ -6,13 +6,4 @@ namespace Providers.DataGrid.Wijmo.Helper.Constants {
         Tooltip = 'wj-tooltip',
         TooltipErrorValidation = 'errorValidation'
     }
-
-    export enum HTMLAttributes {
-        Class = 'class'
-    }
-
-    export enum HTMLEvent {
-        MouseOver = 'mouseover',
-        MouseOut = 'mouseout'
-    }
 }


### PR DESCRIPTION
This PR is to fix the issue with the custom tooltip when used in a Grid with Column Group

### What was happening
* When using the custom tooltip in a Grid with Column Group, the tooltip was not placed in the right column.
* The issue was that the column index returned by Wijmo cannot be used to get the column on the OSDG side when using a Grid with Column Group, because Wijmo does not consider the Column Group as it is done on OSDG side.
* Example: The "Price Tooltip" should have been placed in the Price column instead of the Stock column.
![groupcolumntooltipissue](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/95eff41f-ea3b-40ba-95da-d08010829277)

### What was done
* Changed the Tooltip _setHeaderTooltip method to use the binding instead of the column index to get the column configs.
* Created a new file to place the constants used in the file
* Added a method to set the Column Group header tooltip
* Exposed the tooltip as a Data Grid feature
    * This is necessary so the developer can use the new setColumnGroupHeaderTooltip method

### Test Steps
1. Add a Grid with a Column Group 
2. Add a custom tooltip to one of the columns
3. In runtime, check that the custom tooltip is placed in the correct column.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)


