### PR TITLE
ROU-3712: Dropdown cell change handler returns wrong Id if text is duplicate

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -46,16 +46,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
             // if the ESC key is pressed the e.cancel is true
             if (e.cancel) return;
 
-            // If the Delete or a BackSpace key is pressed, we assume that a change was made
-            if (
-                !!e.data &&
-                !!e.data.key &&
-                (e.data.key === 'Delete' || e.data.key === 'Backspace')
-            ) {
-                e.cancel = false;
-                return;
-            }
-
             // Stores the previous cell value to validate if it was changed in CellEditEnded handler.
             // Related to WJM-27988 that will be fixed in the Wijmo's 2023.2 release
             this._previousValue = s.getCellData(e.row, e.col, false);
@@ -71,10 +61,17 @@ namespace Providers.DataGrid.Wijmo.Feature {
             if (!e.cancel) {
                 // get the new value
                 const newValue = s.getCellData(e.row, e.col, false);
-                if (
+
+                const isNewValue =
                     this._previousValue !== newValue &&
-                    this._previousValue?.toString() !== newValue?.toString()
-                ) {
+                    this._previousValue?.toString() !== newValue?.toString();
+
+                const pressedDeleteBackspaceKey =
+                    !!e.data &&
+                    !!e.data.key &&
+                    (e.data.key === 'Delete' || e.data.key === 'Backspace');
+
+                if (isNewValue || pressedDeleteBackspaceKey) {
                     const column = s.getColumn(e.col);
                     const OSColumn = this._grid
                         .getColumns()

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -55,32 +55,32 @@ namespace Providers.DataGrid.Wijmo.Feature {
             s: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
-            if (!e.cancel) {
-                // get the new value
-                const newValue = s.getCellData(e.row, e.col, false);
+            if (e.cancel) return;
 
-                const isNewValue =
-                    this._previousValue !== newValue &&
-                    this._previousValue?.toString() !== newValue?.toString();
+            // get the new value
+            const newValue = s.getCellData(e.row, e.col, false);
 
-                if (isNewValue) {
-                    const column = s.getColumn(e.col);
-                    const OSColumn = this._grid
-                        .getColumns()
-                        .find((item) => item.provider.index === column.index);
+            const isNewValue =
+                this._previousValue !== newValue &&
+                this._previousValue?.toString() !== newValue?.toString();
 
-                    // The old value can be captured on the dirtyMark feature as it is the one responsible for saving the original values
-                    const oldValue = this._grid.features.dirtyMark.getOldValue(
-                        e.row,
-                        column.binding
-                    );
-                    this._triggerEventsFromColumn(
-                        e.row,
-                        OSColumn.uniqueId,
-                        oldValue,
-                        newValue
-                    );
-                }
+            if (isNewValue) {
+                const column = s.getColumn(e.col);
+                const OSColumn = this._grid
+                    .getColumns()
+                    .find((item) => item.provider.index === column.index);
+
+                // The old value can be captured on the dirtyMark feature as it is the one responsible for saving the original values
+                const oldValue = this._grid.features.dirtyMark.getOldValue(
+                    e.row,
+                    column.binding
+                );
+                this._triggerEventsFromColumn(
+                    e.row,
+                    OSColumn.uniqueId,
+                    oldValue,
+                    newValue
+                );
             }
         }
 

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -39,7 +39,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
          * For this purpose, here we consider null == undefined == ''
          * Bug: it does not work for checkboxes, since the activeEditor.value is always "on"
          */
-        private _cellEditBeforeEndingHandler(
+        private _beginningEditHandler(
             s: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
@@ -54,7 +54,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
         /**
          * Handler for the CellEditEnded.
          */
-        private _cellEditHandler(
+        private _cellEditEndedHandler(
             s: wijmo.grid.FlexGrid,
             e: wijmo.grid.CellRangeEventArgs
         ): void {
@@ -66,12 +66,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     this._previousValue !== newValue &&
                     this._previousValue?.toString() !== newValue?.toString();
 
-                const pressedDeleteBackspaceKey =
-                    !!e.data &&
-                    !!e.data.key &&
-                    (e.data.key === 'Delete' || e.data.key === 'Backspace');
-
-                if (isNewValue || pressedDeleteBackspaceKey) {
+                if (isNewValue) {
                     const column = s.getColumn(e.col);
                     const OSColumn = this._grid
                         .getColumns()
@@ -457,14 +452,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
         }
 
         public build(): void {
-            this._grid.provider.cellEditEnding.addHandler(
-                this._cellEditBeforeEndingHandler.bind(this)
+            this._grid.provider.beginningEdit.addHandler(
+                this._beginningEditHandler.bind(this)
             );
             this._grid.provider.cellEditEnded.addHandler(
-                this._cellEditHandler.bind(this)
+                this._cellEditEndedHandler.bind(this)
             );
             this._grid.provider.pastedCell.addHandler(
-                this._cellEditHandler.bind(this)
+                this._cellEditEndedHandler.bind(this)
             );
             this._grid.features.undoStack.stack.undoingAction.addHandler(
                 this._undoingActionHandler.bind(this)

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -34,10 +34,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
         // }
 
         /**
-         * Handler for the CellEditEnding.
-         * It checks if the cell value effectively changed
-         * For this purpose, here we consider null == undefined == ''
-         * Bug: it does not work for checkboxes, since the activeEditor.value is always "on"
+         * Handler for the beginningEdit.
+         * It stores the previous cell value to validate if it was changed in CellEditEnded handler.
          */
         private _beginningEditHandler(
             s: wijmo.grid.FlexGrid,
@@ -46,7 +44,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
             // if the ESC key is pressed the e.cancel is true
             if (e.cancel) return;
 
-            // Stores the previous cell value to validate if it was changed in CellEditEnded handler.
             // Related to WJM-27988 that will be fixed in the Wijmo's 2023.2 release
             this._previousValue = s.getCellData(e.row, e.col, false);
         }


### PR DESCRIPTION
This PR is for fixing the dropdown with duplicated labels returning the wrong ID and not triggering OnCellValueChange

### What was happening
* When the Dropdown has duplicated labels with different values, the OnCellValueChange returns the wrong ID or is not triggered when changing to an option with the same label.

### What was done
* Now, we store the previous cell value into the beginningEdit, to validate if the value was changed into cellEditEnded. 

### Test Steps
1. Go to a page with a Grid containing dropdowns with duplicated option's labels
2. Change to another option with the same label
3. Check if the OnCellValue Changed was triggered and returns the correct value.

### Screenshots
Before:
![dropdownDuplicatedLabelsIssue](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/ca81027a-5dc6-4519-9471-0ec7d5419b27)

After:
![dropdownDuplicatedLabelsFixed](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/7046681f-01ac-488b-bae3-caaadad632a1)


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

