### PR TITLE
ROU-4486: changes required to expand the usage of setColumnFilterOptions method

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -349,7 +349,17 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     column.columnType ===
                         OSFramework.DataGrid.Enum.ColumnType.Text ||
                     column.columnType ===
-                        OSFramework.DataGrid.Enum.ColumnType.Dropdown
+                        OSFramework.DataGrid.Enum.ColumnType.Dropdown ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Checkbox ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Currency ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Date ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.DateTime ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Number
                 ) {
                     // this column will have both filter types
                     this.changeFilterType(

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -379,7 +379,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                         ).valueFilter.maxValues = maxVisibleOptions;
                 } else {
                     throw new Error(
-                        `The SetColumnFilterOptions client action can only be applied to Text or Dropdowncolumns.`
+                        `The SetColumnFilterOptions client action can only be applied to Text, Number, Currency, Dropdown, Checkbox, Date, DateTime Columns.`
                     );
                 }
             } else {


### PR DESCRIPTION
This PR is not to be accepted!
It only contains the changes required to allow the action `API_Filter\SetColumnFilterOptions` to be used in more columns:
- Text
- Dropdown
- Checkbox 🌟
- Currency 🌟
- Date 🌟
- DateTime 🌟
- Number 🌟