### PR TITLE
ROU-4651: solving incorrect outputs when API invokation fails

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
 	"editor.wordWrapColumn": 170,
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"css.lint.fontFaceProperties": "ignore",
 	"scss.lint.fontFaceProperties": "ignore",

--- a/src/OutSystems/GridAPI/Auxiliary.ts
+++ b/src/OutSystems/GridAPI/Auxiliary.ts
@@ -39,6 +39,7 @@ namespace OutSystems.GridAPI.Auxiliary {
                 OSFramework.DataGrid.Enum.ErrorMessages.Grid_NotFound;
             responseObj.code =
                 OSFramework.DataGrid.Enum.ErrorCodes.CFG_GridNotFound;
+            responseObj.value = defaultFailValue;
             return JSON.stringify(responseObj);
         }
 

--- a/src/OutSystems/GridAPI/Auxiliary.ts
+++ b/src/OutSystems/GridAPI/Auxiliary.ts
@@ -6,6 +6,7 @@ namespace OutSystems.GridAPI.Auxiliary {
     type APIHandler = {
         // eslint-disable-next-line
         callback: any;
+        defaultFailValue?: unknown;
         errorCode: OSFramework.DataGrid.Enum.ErrorCodes;
         gridID: string;
         hasValue?: boolean;
@@ -23,7 +24,8 @@ namespace OutSystems.GridAPI.Auxiliary {
         gridID,
         callback,
         errorCode,
-        hasValue = false
+        hasValue = false,
+        defaultFailValue = undefined
     }: APIHandler): string {
         const responseObj: APIResponse = {
             isSuccess: true,
@@ -50,6 +52,7 @@ namespace OutSystems.GridAPI.Auxiliary {
             responseObj.isSuccess = false;
             responseObj.message = error.message;
             responseObj.code = errorCode;
+            responseObj.value = defaultFailValue;
         }
 
         return JSON.stringify(responseObj);

--- a/src/OutSystems/GridAPI/Pagination.ts
+++ b/src/OutSystems/GridAPI/Pagination.ts
@@ -71,7 +71,6 @@ namespace OutSystems.GridAPI.Pagination {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedPaginationGetCurrentPage,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
@@ -82,7 +81,9 @@ namespace OutSystems.GridAPI.Pagination {
                     );
                 }
                 return grid.features.pagination.pageIndex;
-            }
+            },
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Pagination.GetCurrentPage-end');

--- a/src/OutSystems/GridAPI/Rows.ts
+++ b/src/OutSystems/GridAPI/Rows.ts
@@ -297,8 +297,7 @@ namespace OutSystems.GridAPI.Rows {
                         gridID
                     ).dataSource.updateAddedRowKey(currentRowId, newKey)
                 );
-            },
-            hasValue: true
+            }
         });
 
         Performance.SetMark('Rows.UpdateAddedRowKey-end');

--- a/src/OutSystems/GridAPI/Rows.ts
+++ b/src/OutSystems/GridAPI/Rows.ts
@@ -122,7 +122,8 @@ namespace OutSystems.GridAPI.Rows {
                     ).dataSource.getRowNumberByKey(key)
                 );
             },
-            hasValue: true
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Rows.GetRowNumberByKey-end');

--- a/src/OutSystems/GridAPI/Selection.ts
+++ b/src/OutSystems/GridAPI/Selection.ts
@@ -6,12 +6,12 @@ namespace OutSystems.GridAPI.Selection {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedGetAllSelections,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getAllSelections();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetAllSelections-end');
@@ -31,12 +31,12 @@ namespace OutSystems.GridAPI.Selection {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedGetAllSelectionsData,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getAllSelectionsData();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetAllSelectionsData-end');
@@ -57,12 +57,12 @@ namespace OutSystems.GridAPI.Selection {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedGetCheckedRowsData,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getCheckedRowsData();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetCheckedRowsData-end');
@@ -82,12 +82,12 @@ namespace OutSystems.GridAPI.Selection {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedGetSelectedRowsCount,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectedRowsCount();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetSelectedRowsCount-end');
@@ -107,12 +107,12 @@ namespace OutSystems.GridAPI.Selection {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedGetSelectedRowsData,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectedRowsData();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetSelectedRowsData-end');
@@ -132,12 +132,12 @@ namespace OutSystems.GridAPI.Selection {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedGetSelectionAverage,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectionAverage();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetSelectionAverage-end');
@@ -157,12 +157,13 @@ namespace OutSystems.GridAPI.Selection {
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes
                     .API_FailedGetSelectionCount,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectionCount();
-            }
+            },
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Selection.GetSelectionCount-end');
@@ -181,12 +182,12 @@ namespace OutSystems.GridAPI.Selection {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedGetSelectionMax,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectionMaxMin(true);
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetSelectionMax-end');
@@ -205,12 +206,12 @@ namespace OutSystems.GridAPI.Selection {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedGetSelectionMin,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectionMaxMin(false);
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetSelectionMin-end');
@@ -229,12 +230,12 @@ namespace OutSystems.GridAPI.Selection {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedGetSelectionSum,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.getSelectionSum();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.GetSelectionSum-end');
@@ -253,12 +254,12 @@ namespace OutSystems.GridAPI.Selection {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedHasSelectedRows,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
                 return grid.features.selection.hasSelectedRows();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.HasSelectedRows-end');
@@ -281,7 +282,6 @@ namespace OutSystems.GridAPI.Selection {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedSetRowAsSelected,
-            hasValue: true,
             callback: () => {
                 const grid = GridManager.GetGridById(gridID);
 
@@ -289,7 +289,8 @@ namespace OutSystems.GridAPI.Selection {
                     rowsIndex,
                     isSelected
                 );
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('Selection.SelectRows-end');

--- a/src/OutSystems/GridAPI/Selection.ts
+++ b/src/OutSystems/GridAPI/Selection.ts
@@ -87,7 +87,8 @@ namespace OutSystems.GridAPI.Selection {
 
                 return grid.features.selection.getSelectedRowsCount();
             },
-            hasValue: true
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Selection.GetSelectedRowsCount-end');
@@ -137,7 +138,8 @@ namespace OutSystems.GridAPI.Selection {
 
                 return grid.features.selection.getSelectionAverage();
             },
-            hasValue: true
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Selection.GetSelectionAverage-end');
@@ -187,7 +189,8 @@ namespace OutSystems.GridAPI.Selection {
 
                 return grid.features.selection.getSelectionMaxMin(true);
             },
-            hasValue: true
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Selection.GetSelectionMax-end');
@@ -211,7 +214,8 @@ namespace OutSystems.GridAPI.Selection {
 
                 return grid.features.selection.getSelectionMaxMin(false);
             },
-            hasValue: true
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Selection.GetSelectionMin-end');
@@ -235,7 +239,8 @@ namespace OutSystems.GridAPI.Selection {
 
                 return grid.features.selection.getSelectionSum();
             },
-            hasValue: true
+            hasValue: true,
+            defaultFailValue: -1
         });
 
         Performance.SetMark('Selection.GetSelectionSum-end');
@@ -289,8 +294,7 @@ namespace OutSystems.GridAPI.Selection {
                     rowsIndex,
                     isSelected
                 );
-            },
-            hasValue: true
+            }
         });
 
         Performance.SetMark('Selection.SelectRows-end');

--- a/src/OutSystems/GridAPI/View.ts
+++ b/src/OutSystems/GridAPI/View.ts
@@ -12,10 +12,10 @@ namespace OutSystems.GridAPI.View {
             gridID,
             errorCode:
                 OSFramework.DataGrid.Enum.ErrorCodes.API_FailedGetViewLayout,
-            hasValue: true,
             callback: () => {
                 return GridManager.GetGridById(gridID).getViewLayout();
-            }
+            },
+            hasValue: true
         });
 
         Performance.SetMark('View.GetViewLayout-end');


### PR DESCRIPTION
This PR contains a potential solution for how the APIs can start returning, in case of error, values more aligned with that.
The following APIs, were changed:
- `OutSystems.GridAPI.Rows.GetRowNumberByKey`
- `OutSystems.GridAPI.Pagination.GetCurrentPage`

![image](https://github.com/OutSystems/outsystems-datagrid/assets/10534623/a165e6ff-1ab5-4bbd-976f-30e6b9671868)



### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

