### PR TITLE
ROU-4659: Open SetColumnFilterOptions to work with more column types

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -349,7 +349,17 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     column.columnType ===
                         OSFramework.DataGrid.Enum.ColumnType.Text ||
                     column.columnType ===
-                        OSFramework.DataGrid.Enum.ColumnType.Dropdown
+                        OSFramework.DataGrid.Enum.ColumnType.Dropdown ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Checkbox ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Currency ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Date ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.DateTime ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Number
                 ) {
                     // this column will have both filter types
                     this.changeFilterType(

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -379,7 +379,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                         ).valueFilter.maxValues = maxVisibleOptions;
                 } else {
                     throw new Error(
-                        `The SetColumnFilterOptions client action can only be applied to Text or Dropdowncolumns.`
+                        `The SetColumnFilterOptions client action can only be applied to Text, Number, Currency, Dropdown, Checkbox, Date, DateTime Columns.`
                     );
                 }
             } else {

--- a/src/Providers/DataGrid/Wijmo/Helper/CellTemplateFactory.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/CellTemplateFactory.ts
@@ -16,7 +16,10 @@ namespace Providers.DataGrid.Wijmo.Helper.CellTemplateFactory {
         let cellTemplate: wijmo.grid.ICellTemplateFunction;
 
         const hasFixedText = binding.startsWith('$');
-        const hasExternalURL = externalURL?.substring(0, 4) === 'http';
+        const hasExternalURL = externalURL
+            ?.toLocaleLowerCase()
+            .startsWith('http');
+
         const url = hasExternalURL
             ? externalURL
             : '${item.' + externalURL + '}';


### PR DESCRIPTION
This PR is for open SetColumnFilterOptions to work with more column types

### What was done
* Add the capability to set column filter options to work with Number, Currency, Date and DateTime.
    * Edited the setColumnFilterOptions method to consider Number, Currency, Date and DateTime column types.
    * Edited the Error Message.
* Added toLowerCase() when checking if the "ExternalLink" options from the Action column is a binding or an external link.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [x] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

