### PR TITLE
ROU-4695: Fix an issue where the LongInteger, Integer and Decimal delimiter is no longer present at ActionColumn.

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Helper/CellTemplateFactory.ts
+++ b/src/Providers/DataGrid/Wijmo/Helper/CellTemplateFactory.ts
@@ -23,9 +23,7 @@ namespace Providers.DataGrid.Wijmo.Helper.CellTemplateFactory {
         const url = hasExternalURL
             ? externalURL
             : '${item.' + externalURL + '}';
-        const text = hasFixedText
-            ? binding.substring(1)
-            : '${item.' + binding + '}';
+        const text = hasFixedText ? binding.substring(1) : undefined;
 
         let imgAltText = '';
         if (altText !== undefined) {


### PR DESCRIPTION
This PR will fix an issue at ActionColumn when LongInteger, Integer or Decimal type data was in use once the specification of comma delimitation was being not set properly.

Before the fix:
![Screenshot 2023-12-29 at 16 06 31](https://github.com/OutSystems/outsystems-datagrid/assets/5339917/86389112-74e0-4666-96be-3db4948f0162)

After the fix:
![Screenshot 2023-12-29 at 16 06 38](https://github.com/OutSystems/outsystems-datagrid/assets/5339917/70f7274e-3676-456d-9710-321392deddfe)
