### PR TITLE
ROU-4691: Column Filter does not reflect the correct value when using FilterByCondition API

### DIFF
--- a/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
+++ b/src/OSFramework/DataGrid/Enum/ErrorMessages.ts
@@ -14,6 +14,7 @@ namespace OSFramework.DataGrid.Enum {
         AutoGenerateGridWrite = 'The auto generation of columns based on Data is not available when the Grid is editable. Please use ArrangeData action for this scenario.',
         Column_NotFound = 'Column not found',
         CustomizeExportingMessageEmptyString = 'It seems you are passing an empty message. Please pass a valid message.',
+        Filter_InvalidDataType = 'It seems you are trying to filter a Number/Currency column with a value that is not a number.',
         FreezeColumnPositiveNumberExpected = 'Unable to freeze column. Please use a positive number.',
         Grid_NotFound = 'Grid not found.',
         InvalidColumnIdentifier = 'It seems you are not passing a valid column.',

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -192,15 +192,35 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 const columnFilter = this._filter.getColumnFilter(
                     column.config.binding
                 ).conditionFilter;
+                let isNumericalColumn =
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Calculated ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Currency ||
+                    column.columnType ===
+                        OSFramework.DataGrid.Enum.ColumnType.Number;
 
                 if (values.length > 0) {
                     const condition1 = values[0];
                     const condition2 = values[1];
 
+                    if (isNumericalColumn) {
+                        if (
+                            isNaN(parseFloat(condition1.value)) ||
+                            (condition2 && isNaN(parseFloat(condition2.value)))
+                        ) {
+                            throw new Error(
+                                OSFramework.DataGrid.Enum.ErrorMessages.Filter_InvalidDataType
+                            );
+                        }
+                    }
+
                     columnFilter.condition1.value =
                         this._getFilterConditionValue(
                             column.columnType,
-                            condition1.value
+                            isNumericalColumn
+                                ? parseFloat(condition1.value)
+                                : condition1.value
                         );
                     columnFilter.condition1.operator =
                         wijmo.grid.filter.Operator[condition1.operatorTypeId];
@@ -210,7 +230,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
                         columnFilter.condition2.value =
                             this._getFilterConditionValue(
                                 column.columnType,
-                                condition2.value
+                                isNumericalColumn
+                                    ? parseFloat(condition2.value)
+                                    : condition2.value
                             );
                         columnFilter.condition2.operator =
                             wijmo.grid.filter.Operator[

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -190,7 +190,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
             const column = this._grid.getColumn(columnId);
             if (column) {
                 const columnFilter = this._filter.getColumnFilter(
-                    column.config.binding
+                    column.provider
                 ).conditionFilter;
                 const isNumericalColumn =
                     column.columnType ===
@@ -271,7 +271,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                         OSFramework.DataGrid.Enum.ColumnType.DateTime;
 
                 const columnFilter = this._filter.getColumnFilter(
-                    column.config.binding
+                    column.provider
                 ).valueFilter;
 
                 // we receive values as an array ["Brazil", "Portugal"], but wijmo expects an object

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -192,7 +192,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
                 const columnFilter = this._filter.getColumnFilter(
                     column.config.binding
                 ).conditionFilter;
-                let isNumericalColumn =
+                const isNumericalColumn =
                     column.columnType ===
                         OSFramework.DataGrid.Enum.ColumnType.Calculated ||
                     column.columnType ===

--- a/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ColumnFilter.ts
@@ -204,15 +204,16 @@ namespace Providers.DataGrid.Wijmo.Feature {
                     const condition1 = values[0];
                     const condition2 = values[1];
 
-                    if (isNumericalColumn) {
-                        if (
-                            isNaN(parseFloat(condition1.value)) ||
-                            (condition2 && isNaN(parseFloat(condition2.value)))
-                        ) {
-                            throw new Error(
-                                OSFramework.DataGrid.Enum.ErrorMessages.Filter_InvalidDataType
-                            );
-                        }
+                    // If it is a numerical column and one of the conditions' value is not a number
+                    // Then throw an error
+                    if (
+                        isNumericalColumn &&
+                        (isNaN(parseFloat(condition1.value)) ||
+                            (condition2 && isNaN(parseFloat(condition2.value))))
+                    ) {
+                        throw new Error(
+                            OSFramework.DataGrid.Enum.ErrorMessages.Filter_InvalidDataType
+                        );
                     }
 
                     columnFilter.condition1.value =


### PR DESCRIPTION
This PR is to fix the filter popup not displaying the correct value when using FilterByCondition API in a Currency Column. It also corrects the issue of the filter not being applied to the correct column when the Grid has columns with the same binding.

### What was happening
* When using the FilterByCondition API to set a filter on a Currency column, the value passed to the _getFilterConditionValue was a string instead of a number.
   * This prevented the condition value from appearing correctly in the filter popup. 
* When using the FilterByCondition API to set a filter to a column with duplicated binding in a Grid, the filter was always applied to the first column corresponding to the binding.

### What was done
* In the ColumnFilter.byCondition method, added an evaluation was added to check if the target column is numerical. If true, we check if the value is a number and convert it.
* In the ColumnFilter.byCondition and ColumnFilter.byValue, edit how a filter is applied to a column. Instead of using the binding, now we use the column provider's instance.

### Test Steps
#### Test 1:
1. Go to a page with a Grid that contains a Currency column
2. Use the FilterByCondition API to set a new filter to the Currency column
3. Open the column filter
4. Check that the condition value is displayed correctly

#### Test 2:
1. Go to a page with a Grid that contains two columns with the same binding
2. Use the FilterByCondition API to set a new filter to a column
3. Check that the desired column is filtered correctly
4. Repeat for another column with the same binding.


### Screenshots
Before first fix: 
![filterbycondition_isse](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/ab8bf0d5-4de3-471b-9ab4-d43fecee175f)

After first fix:
![filterbycondition_fix](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/2f4f87eb-749a-4aaa-b054-97f63624ce51)

Before second fix:
![filterbycondition_samebinding_issue](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/31188283-d4f9-4d49-9e8b-04b2a46deaed)

After second fix:
![filterbycondition_samebinding_fix](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/9d96e3b5-143a-4cac-9aa1-d304782577ca)



### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

