### PR TITLE
ROU-4765: GetChangedLines detect changes when Dropdown cell to the original value

### DIFF
--- a/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
@@ -80,6 +80,8 @@ namespace OSFramework.DataGrid.Grid {
 					saveConvertion('date', key);
 				}
 				return handleValue(value);
+			// To avoid issue with the GetChangedLines when returnin the Dropdown cell to its original vlaue,
+			// we need to match the dataMap values data type of the Dropdown Column converting the Dropdown Column values to string.
 			} else if (typeMap.get(key) === 'Dropdown') {
 				return value.toString();
 			}

--- a/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
+++ b/src/OSFramework/DataGrid/Grid/AbstractDataSource.ts
@@ -80,6 +80,8 @@ namespace OSFramework.DataGrid.Grid {
 					saveConvertion('date', key);
 				}
 				return handleValue(value);
+			} else if (typeMap.get(key) === 'Dropdown') {
+				return value.toString();
 			}
 			return value;
 		});


### PR DESCRIPTION
This PR is for fix the GetChangedLines detecting changes when the Dropdown cell returns to its original value.

### What was happening
* In a Dropdown column, the Value attribute of the DropdownOptionList is always a Text by default. This way, even if the mapped values are of other data type, it will always be converted to Text.
![image](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/8a6828bd-8144-4772-ba47-ec1177d5fc03)
* However, the Dropdown values of the data source are not automatically converted to Text.
![image](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/61e416aa-6ca9-4bb8-8663-110407378db6)
* In the cases when the Dropdown Column values are of a different data type then Text, when changing a Dropdown value manually and then returning it to the original value, it will be replaced by a Text Value. This way a change is detected by the GetChangedLines.
![image](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/75db933a-55c1-41f7-ba67-d2fe0be75b12)


### What was done
* To fix this, we need to assure that the DropdownOptionList Values and the Dropdown Column values will always have the same data type. 
* To achieve that, we added a new validation to the ToJSONFormat() method to convert the Dropdown Column values to string.

### Screenshots
Before fix:
![getChangedLinesDropdownBeforefix](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/c9c0c982-1b91-4b67-9b15-2c04cd207827)
After fix:
![getChangedLinesDropdownAfterfix](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/fde3d414-1191-4931-be36-539d8f3bcc18)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

