### PR TITLE
ROU-4768: Fix OnCellValueChange returning the dropdown label instead of the value

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -602,11 +602,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			triggerOnCellValueChange = true
 		): void {
 			// This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
-			const currValue = this._grid.provider.getCellData(
-				rowNumber,
-				column.provider.index,
-				column.columnType === OSFramework.DataGrid.Enum.ColumnType.Dropdown
-			);
+			const currValue = this._grid.provider.getCellData(rowNumber, column.provider.index, false);
 
 			//If we decide not to trigger the column events we will skip this step
 			if (triggerOnCellValueChange) {
@@ -634,11 +630,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				// We need to skip Group Column since it is not a column we can validate
 				if (column.columnType !== OSFramework.DataGrid.Enum.ColumnType.Group) {
 					// This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
-					const currValue = this._grid.provider.getCellData(
-						rowNumber,
-						column.provider.index,
-						column.columnType === OSFramework.DataGrid.Enum.ColumnType.Dropdown
-					);
+					const currValue = this._grid.provider.getCellData(rowNumber, column.provider.index, false);
 
 					// Triggers the events of OnCellValueChange associated to a specific column in OS
 					this._triggerEventsFromColumn(rowNumber, column.uniqueId, currValue, currValue);


### PR DESCRIPTION
This PR is for fixing the OnCellValueChange returning the dropdown label instead of the value when the SetCellData is called.

### What was happening
* When triggering the OnCellValueChange after calling the SEeCellData, it returned the dropdown's formatted value (label) instead of the option id/key. 

### What was done
* In the Wijmo's getCellData method, we now set the last argument to false, this way we get the dropdown option id/key instead of the dropdown label.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [] requires changes in OutSystems (if so, provide a module with changes)
* [x] requires new sample page in OutSystems (if so, provide a module with changes)

