### PR TITLE
ROU-4829: Fix MarkChangesAsSavedByKey not updating the cleaning invalid rows

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -369,6 +369,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			rowKeys.forEach((element) => {
 				if (element !== '') {
 					this._metadata.clearPropertyByRowKey(element, this._internalLabel);
+					this._setRowStatusByKey(element, true);
 				}
 			});
 			this._grid.provider.invalidate(); //Mark to be refreshed


### PR DESCRIPTION
This PR is for fix MarkChangesAsSavedByKey not updating the cleaning invalid rows

[Sample page](url)

### What was happening
* When using the MarkChangesAsSavedByKey Client Action with the ForceCleanInvalids parameter set to true and then calling the GetChangedLines, the HasInvalid property response was always true.
    * This happened because we were not updating the invalidRows Set object when the MarkChangesAsSavedByKey is called.

### What was done
* Added the _setRowStatusByKey method to the clearByRowKeys. This will update the rows invalidRows Set object.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

