### PR TITLE
ROU-4722: Fix console error when opening a child dropdown without options

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -273,6 +273,7 @@ namespace Providers.DataGrid.Wijmo.Column {
 						const validValues = values.filter((x) => x.parentKey === value.toString());
 						return validValues;
 					}
+					return [];
 				};
 			}
 		}

--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -268,7 +268,6 @@ namespace Providers.DataGrid.Wijmo.Column {
 						value = value[colBinding[i]];
 					}
 
-					// if there is no value, we don't return anything
 					if (value) {
 						const validValues = values.filter((x) => x.parentKey === value.toString());
 						return validValues;


### PR DESCRIPTION
This PR is to fix the console error when opening a child dropdown without options

### What was happening
* In a Grid with two Dropdown columns dependent on each other, a console error occurs when the parent dropdown is erased and the child dropdown is opened.
* The error happened because nothing was returned in the getFilteredItems method when no option was selected in the parent dropdown. So Wijmo's code tried to access an undefined value.
![image](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/ad5b4dc7-b74b-4f69-bc23-115784e2c1fe)

### What was done
* Fix the getFilteredItems to return an empty array when the parent dropdown value is empty.

### Screenshots
Before:
![gridDropdownError](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/556be9f7-11d2-4a39-9bc3-0fdd3ebc3d43)
After:
![gridDropdownFixed](https://github.com/OutSystems/outsystems-datagrid/assets/108938618/421534ac-457e-4114-8fdb-8000300e219b)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

