### PR TITLE
ROU-4896: Fix child dropdown being erased when using ApplyRowValidations

### DIFF
--- a/src/OSFramework/DataGrid/Event/Column/ColumnEventsManager.ts
+++ b/src/OSFramework/DataGrid/Event/Column/ColumnEventsManager.ts
@@ -45,7 +45,13 @@ namespace OSFramework.DataGrid.Event.Column {
 		 * @param value Value to be passed to OS in the type of a string.
 		 * @param rowNumber (Optional) Number of the row in which the event ocurrs.
 		 */
-		public trigger(eventType: ColumnEventType, value: string, oldValue?: string, rowNumber?: number): void {
+		public trigger(
+			eventType: ColumnEventType,
+			value: string,
+			oldValue?: string,
+			rowNumber?: number,
+			isFromApplyRowValidations = false
+		): void {
 			if (this.events.has(eventType)) {
 				const handlerEvent = this.events.get(eventType);
 
@@ -64,7 +70,8 @@ namespace OSFramework.DataGrid.Event.Column {
 							this._column.widgetId, // ID of the Column block in which the cell value has changed.
 							rowNumber, // Number of the row in which the cell value has changed.
 							oldValue, // Value of the cell before its value has changed (Old)
-							value // Value of the cell after its value has changed (New)
+							value, // Value of the cell after its value has changed (New)
+							isFromApplyRowValidations
 						);
 						break;
 					case ColumnEventType.OnColumnReorder:

--- a/src/OSFramework/DataGrid/Event/Column/OnCellValueChange.ts
+++ b/src/OSFramework/DataGrid/Event/Column/OnCellValueChange.ts
@@ -7,9 +7,16 @@ namespace OSFramework.DataGrid.Event.Column {
 	 * @extends AbstractColumnEvent
 	 */
 	export class OnCellValueChange extends AbstractColumnEvent {
-		public trigger(gridID: string, columnID: string, rowNumber: number, oldValue: string, newValue: string): void {
+		public trigger(
+			gridID: string,
+			columnID: string,
+			rowNumber: number,
+			oldValue: string,
+			newValue: string,
+			isFromApplyRowValidations = false
+		): void {
 			this.handlers.slice(0).forEach((h) => {
-				Helper.SyncInvocation(h, gridID, rowNumber, columnID, oldValue, newValue);
+				Helper.SyncInvocation(h, gridID, rowNumber, columnID, oldValue, newValue, isFromApplyRowValidations);
 			});
 		}
 	}

--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -116,11 +116,14 @@ namespace Providers.DataGrid.Wijmo.Column {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			oldValue: any,
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			newValue: any
+			newValue: any,
+			isFromApplyRowValidations = false
 		): void {
 			if (oldValue !== newValue && oldValue.toString() !== newValue.toString()) {
 				this.grid.features.dirtyMark.saveOriginalValue(rowNumber, this.provider.index);
 			}
+
+			if (isFromApplyRowValidations) return;
 
 			const column = this.grid.getColumn(columnID);
 

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -84,7 +84,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			column: OSFramework.DataGrid.Column.IColumn,
 			rowNumber: number,
 			newValue: string,
-			oldValue: string
+			oldValue: string,
+			isFromApplyRowValidations = false
 		): void {
 			if (
 				column.hasEvents &&
@@ -94,7 +95,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					OSFramework.DataGrid.Event.Column.ColumnEventType.OnCellValueChange,
 					this._convertToFormat(column, newValue),
 					this._convertToFormat(column, oldValue),
-					rowNumber
+					rowNumber,
+					isFromApplyRowValidations
 				);
 			}
 		}
@@ -268,13 +270,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			oldValue: any,
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			newValue: any
+			newValue: any,
+			isFromApplyRowValidations = false
 		) {
 			const column = this._grid.getColumn(columnUniqueID);
 
 			if (column !== undefined) {
 				this._setCellStatus(column, rowNumber, newValue);
-				this._handleOnCellChangeEvent(column, rowNumber, newValue, oldValue);
+				this._handleOnCellChangeEvent(column, rowNumber, newValue, oldValue, isFromApplyRowValidations);
 			}
 		}
 
@@ -634,7 +637,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					const currValue = this._grid.provider.getCellData(rowNumber, column.provider.index, false);
 
 					// Triggers the events of OnCellValueChange associated to a specific column in OS
-					this._triggerEventsFromColumn(rowNumber, column.uniqueId, currValue, currValue);
+					this._triggerEventsFromColumn(rowNumber, column.uniqueId, currValue, currValue, true);
 				}
 			});
 		}


### PR DESCRIPTION
This PR is to fix the child dropdown being erased when using ApplyRowValidations.

### What was happening
* When using the ApplyRowValidations Client Action in a Grid with Dropdown Dependency, the child dropdown cell was being erased
* This happened because the ApplyRowValidations triggers the OnCellValueChange event of the Column and the Dropdown Column's _parentCellValueChangeHandler method was not considering this scenario. 

### What was done
* Added a flag to check when the ApplyRowValidations API triggered the OnCellValueChange event and validate if it should erase the child dropdown value or not.

### Test Steps
1. Go to a page with a Grid with Dropdown Dependency
2. Run the ApplyRowValidations Client Action
3. Check that no cells were erased
4. Check that the OnCellValueChange was triggered once for each column


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

