### PR TITLE
ROU-4901: Fix click event listener not being added and removed correctly

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ClickEvent.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ClickEvent.ts
@@ -6,6 +6,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			OSFramework.DataGrid.Interface.IBuilder,
 			OSFramework.DataGrid.Interface.IDisposable
 	{
+		private _cellClickEventHandler: OSFramework.DataGrid.Callbacks.Generic;
 		protected _grid: Providers.DataGrid.Wijmo.Grid.IGridWijmo;
 
 		constructor(
@@ -37,11 +38,13 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		}
 
 		public build(): void {
-			this.setCellClickEvent(this._raiseCellClickEvent.bind(this));
+			this._cellClickEventHandler = this._raiseCellClickEvent.bind(this);
+			this.setCellClickEvent(this._cellClickEventHandler);
 		}
 
 		public dispose(): void {
-			this.removeCellClickEvent(this._raiseCellClickEvent.bind(this));
+			this.removeCellClickEvent(this._cellClickEventHandler);
+			this._cellClickEventHandler = undefined;
 		}
 
 		public removeCellClickEvent(callback: (ev: MouseEvent) => void): void {


### PR DESCRIPTION
This PR is for fix click event listener not being added and removed correctly.

### What was done
* Added a new private property to the ClickEvent Class do store the event instance and used it to add and remove the event listener.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

