### PR TITLE
Removed platform type

### DIFF
--- a/gulp/DefaultSpecs.js
+++ b/gulp/DefaultSpecs.js
@@ -14,7 +14,6 @@ const constants = {
 	// list of platforms to compile and create scss files.
 	platformTarget: {
 		default: '',
-		o11: 'O11',
 	},
 };
 


### PR DESCRIPTION
This PR will update DefaultSpecs in order to remove a platform type that was used for testing proposes.