### PR TITLE
ROU-0: rollback TypeScript and type doc versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "UI Components"
   ],
   "devDependencies": {
-    "@types/lodash": "^4.17.4",
+    "@types/lodash": "^4.17.5",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "@typescript-eslint/parser": "^6.19.1",
     "browser-sync": "^3.0.2",
@@ -52,9 +52,9 @@
     "stylelint-config-prettier": "^9.0.5",
     "stylelint-order": "^6.0.4",
     "stylelint": "^14.16.1",
-    "typedoc-plugin-merge-modules": "^5.1.0",
-    "typedoc-umlclass": "^0.9.0",
-    "typedoc": "^0.25.13",
-    "typescript": "^5.4.5"
+    "typedoc": "^0.23.9",
+    "typedoc-plugin-merge-modules": "^4.0.1",
+    "typedoc-umlclass": "^0.7.0",
+    "typescript": "^4.5.0"
   }
 }


### PR DESCRIPTION
This PR is to rollback some dependencies since the docs generation started to fail: 
- rollback TypeScript version back to `v4.5.0`
- rollback typedoc version back to:
    ```
    "typedoc": "^0.23.9",
    "typedoc-plugin-merge-modules": "^4.0.1",
    "typedoc-umlclass": "^0.7.0",
    ```
- updated `@types/lodash`