### PR TITLE
ROU-10900 Updated _showLoadingMessage to stop using inline styles

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/Export.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Export.ts
@@ -51,7 +51,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				this._grid.uniqueId
 			).parentElement;
 
-			const loadingPlaceholderContent = `<div class="datagrid-loading heading4 OSInline" style="width: 100%; height: 100%;"><i class="icon fa-spin fa fa-spinner fa-1x"></i><div class="OSInline" style="margin-left: 10px;">${this._loadingMessage}</div></div>`;
+			const loadingPlaceholderContent = `<div class="datagrid-loading full-size heading4 OSInline"><i class="icon fa-spin fa fa-spinner fa-1x"></i><div class="ml-10 OSInline">${this._loadingMessage}</div></div>`;
 			const createdDivElem = document.createElement('div');
 			createdDivElem.className = OSFramework.DataGrid.Helper.Constants.overlayExportFeedbackCss;
 			createdDivElem.innerHTML = loadingPlaceholderContent;

--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -1055,7 +1055,7 @@
     -servicestudio-position: relative;
     -servicestudio-right: 0;
     -servicestudio-width: 160px;
-    -servicestudio-z-index: 2;
+    -servicestudio-z-index: 3;
     -servicestudio-margin-top: -35px;
 }
 
@@ -1143,6 +1143,15 @@
     border-radius: 5px;
     color: #fff;
     padding: 2px 4px 2px;
+}
+
+.full-size {
+  width: 100%;
+  height: 100%;
+}
+
+.ml-10 {
+  margin-left: 10px;
 }
 
 /* Tooltip class */


### PR DESCRIPTION
This PR will update the framework method `_showLoadingMessage` to stop using inline styles.

### What was happening
* In O11, when dealing with platform settings related to CSP and `unsafe-inline`, we identified an improvement we could make in the framework. 


### What was done
* Added the following CSS utility classes
* Updated the framework method `_showLoadingMessage` to stop using inline styles and used the CSS utility classes mentioned above.
````
.full-size {
  width: 100%;
  height: 100%;
}

.ml-10 {
  margin-left: 10px;
}
````

### Screenshot
![image](https://github.com/OutSystems/outsystems-datagrid/assets/29493222/a398afc8-7bff-4d49-9ec8-e77665573abd)


### Test Steps
1. Go to a screen containing a Data Grid instance
2. On the dev tool’s console run → `OutSystems.GridAPI.GridManager.GetActiveGrid().features.export._showLoadingMessage()`
3. Check that the loading status continues to work as expected


### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems 
* [ ] requires new sample page in OutSystems 

