### PR TITLE
ROU-10824: change the way context menu order is calculated

### DIFF
--- a/src/OSFramework/DataGrid/Feature/Auxiliar/MenuItem.ts
+++ b/src/OSFramework/DataGrid/Feature/Auxiliar/MenuItem.ts
@@ -12,8 +12,6 @@ namespace OSFramework.DataGrid.Feature.Auxiliar {
 		public items: MenuItem[] = [];
 		/** The label or display name on the context menu */
 		public label: string;
-		/** Order of the element on a menu, calculated based on DOM element position */
-		public order: number;
 		/** Parent Id reference */
 		public parentMenuItemId: string;
 		/** Menu item string identifier */

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -47,19 +47,24 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			menuItem.parentMenuItemId = this._getMenuParentId(menuItem.uniqueId);
 
 			//Define menu item's order
-			menuItem.order = this._defineMenuItemOrder(menuItem.uniqueId);
+			const menuItemOrder = this._defineMenuItemOrder(menuItem.uniqueId);
 
-			//If this menuItem is rootItem, means has no parent menu item
-			if (menuItem.isRootItem) {
-				this._rootMenuItems.push(menuItem);
-			}
-			//Otherwise find its parent and save it as a child
-			else {
-				this._menuItems.get(menuItem.parentMenuItemId).items.push(menuItem);
+			//If it is a root item, push it to the rootMenuItems array.
+			//Otherwise, get the correct array.
+			const arrayItem = menuItem.isRootItem
+				? this._rootMenuItems
+				: this._menuItems.get(menuItem.parentMenuItemId).items;
+
+			//Check if it is the last item, if so, push it to the end of the array.
+			//Otherwise, insert it in the correct position.
+			const isLastItem = menuItemOrder === arrayItem.length;
+
+			if (isLastItem) {
+				arrayItem.push(menuItem);
+			} else {
+				arrayItem.splice(menuItemOrder, 0, menuItem);
 			}
 
-			//Sort menu by order - Usefull when the developer inserts a IF statement hiding/showing elements
-			this._sortMenuItems(this._rootMenuItems);
 			//If the menu is opening, let's refresh the itemsSource
 			if (this._isOpening) {
 				this._provider.itemsSource.refresh();

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -272,12 +272,12 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		 * Sort menu by its order
 		 * @param items list of menu items
 		 */
-		private _sortMenuItems(items: OSFramework.DataGrid.Feature.Auxiliar.MenuItem[]) {
-			items.sort((a, b): number => {
-				this._sortMenuItems(a.items);
-				return a.order - b.order;
-			});
-		}
+		// private _sortMenuItems(items: OSFramework.DataGrid.Feature.Auxiliar.MenuItem[]) {
+		// 	items.sort((a, b): number => {
+		// 		this._sortMenuItems(a.items);
+		// 		return a.order - b.order;
+		// 	});
+		// }
 		public get contextMenuEvents(): OSFramework.DataGrid.Event.Feature.ContextMenuEventManager {
 			return this._contextMenuEvents;
 		}

--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -268,16 +268,6 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			}
 		}
 
-		/**
-		 * Sort menu by its order
-		 * @param items list of menu items
-		 */
-		// private _sortMenuItems(items: OSFramework.DataGrid.Feature.Auxiliar.MenuItem[]) {
-		// 	items.sort((a, b): number => {
-		// 		this._sortMenuItems(a.items);
-		// 		return a.order - b.order;
-		// 	});
-		// }
 		public get contextMenuEvents(): OSFramework.DataGrid.Event.Feature.ContextMenuEventManager {
 			return this._contextMenuEvents;
 		}
@@ -345,12 +335,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			host.addEventListener('contextmenu', this._handleRightClick.bind(this), true);
 		}
 
-		public changeProperty(
-			menuItemId: string,
-			propertyName: string,
-			// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-			propertyValue: any
-		): void {
+		public changeProperty(menuItemId: string, propertyName: string, propertyValue: unknown): void {
 			const menuItem = this._menuItems.get(menuItemId);
 			if (menuItem) {
 				if (menuItem.hasOwnProperty(propertyName)) {


### PR DESCRIPTION
This PR is for changing the way that the context menu item order is calculated when adding it. 
The current change makes the order set by the developer to be kept  in runtime in the IDE.

### What was happening
- When a new element was added to the context menu, the order in which it appeared in runtime, could differ from the order in made in the IDE

### What was done
- Changed the way the order is calculated:
   - Instead of being calculated and then sorting the array, the code will now insert the element immediately in the right position;
- Removed field order from the context menu item object;

### Test Steps
1. Go to the [test page](https://outsystemsui-dev.outsystemsenterprise.com/OSDataGridAutomation_ROU10824/ContextMenu_Dynamic)
2. Right click on the column Price (in any cell)
3. The ContextMenu should appear containing the elements in the following order:
    - This is the Price column
    - (separator)
    - Copy
    - Copy with headers
    - (separator)
    - Export
        - to CSV
        - to Excel
     - (separator)
     - Freeze column(s)
     - Unfreeze column(s)
3. Close the Context Menu
4. Right click on the column Stock (in any cell)
5. The ContextMenu should appear containing the elements in the following order:
    - Copy
    - Copy with headers
    - (separator)
    - Export
        - to CSV
        - (separator)
        - Stock column!
        - (separator)
        - to Excel
     - (separator)
     - Freeze column(s)
     - Unfreeze column(s)

### Checklist
-   [x] tested locally
-   [x] documented the code
-   [x] clean all warnings and errors of eslint
-   [ ] requires changes in OutSystems (if so, provide a module with changes)
-   [ ] requires new sample page in OutSystems (if so, provide a module with changes)
