### PR TITLE
ROU-4896: Remove OnCellValueChange trigger from ApplyRowValidations API

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -633,8 +633,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					// This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
 					const currValue = this._grid.provider.getCellData(rowNumber, column.provider.index, false);
 
-					// Triggers the events of OnCellValueChange associated to a specific column in OS
-					this._triggerEventsFromColumn(rowNumber, column.uniqueId, currValue, currValue);
+					this._setCellStatus(column, rowNumber, currValue);
 				}
 			});
 		}


### PR DESCRIPTION
This PR is to remove the OnCellValueChange trigger from ApplyRowValidations API

### What was happening
- When using the ApplyRowValidations Client Action in a Grid with Dropdown Dependency, the child dropdown cell was being erased
- This happened because the ApplyRowValidations triggers the OnCellValueChange event of the Column and the Dropdown Column's _parentCellValueChangeHandler method was not considering this scenario.

### What was done
* Removed the OnCellValueChange event trigger when calling the ApplyRowValidations. 
* This intruduces a breaking change.

### Test Steps

1. Go to a page with a Grid with Dropdown Dependency
2. Run the ApplyRowValidations Client Action
3. Check that no cells were erased
4. Check that the OnCellValueChange was not triggered

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

