### PR TITLE
ROU-10774: Fix additional spaces when adding a new class to cssClass and cssClassAll

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/Styling.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Styling.ts
@@ -13,8 +13,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			let classList = [];
 			const column = this._grid.getColumn(columnID);
 
-			if (column) {
-				const classListString = column.provider.cssClass || ' ';
+			if (column && column.provider.cssClass) {
+				const classListString = column.provider.cssClass;
 				classList = classListString.split(' ');
 			}
 
@@ -25,8 +25,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			let classList = [];
 			const column = this._grid.getColumn(columnID);
 
-			if (column) {
-				const classListString = column.provider.cssClassAll || ' ';
+			if (column && column.provider.cssClassAll) {
+				const classListString = column.provider.cssClassAll;
 				classList = classListString.split(' ');
 			}
 


### PR DESCRIPTION
This PR is to fix the additional spaces when adding a new class to cssClass and cssClassAll.

### What was done
* Check if classList is not empty before splitting the string into an array. If empty, return a empty array.

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

