### PR TITLE
ROU-10979: Fix visual issue when using frozen columns with dropdowns 

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -279,6 +279,12 @@
     filter: drop-shadow(10px 1px 5px rgba(1, 1, 1, 0.08));
 }
 
+/* Overrides scenarios where we have for instance elements like dropdowns on top of it when having frozen columns*/
+div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
+    z-index: 3 !important;
+}
+
+
 .wj-cell.wj-state-invalid.wj-header.wj-alt:not(.wj-state-multi-selected),
 .wj-cell.wj-state-invalid.wj-header.wj-header-alt:not(.wj-state-multi-selected),
 .wj-cell.wj-alt {


### PR DESCRIPTION
### What was happening

* When using Dropdown Server Side, Dropdown Search, Dropdown Tags, and Date Pickers.

### What was done
* Added a specific selector to override the style since the z-index is being handled inline by Wijmo Flexgrid

### Test Steps
1. Open a screen with a Dropdown Server Side on top of a Grid
2. Open the Dropdown and check the ballon is now over all the Grid elements
3. Repeated the same steps for Dropdown Search, Dropdown Tags, and Date Picker


### Screenshots
- Before: 

![image](https://github.com/user-attachments/assets/5b1f8c6c-1042-46bc-9fcf-4e5b2bc859b8)


- After:
![image](https://github.com/user-attachments/assets/a88dd2ff-dee7-488e-8be8-86babe7fe282)



### Checklist
* [X] tested locally
* [X] documented the code


