### PR TITLE
ROU-11162: Fix alignment issue in filters when used on a popup

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -151,6 +151,7 @@
     border-bottom: var(--datagrid-cell-border-bottom);
     border-right: var(--datagrid-cell-border-right);
     color: var(--datagrid-cell-color);
+    font-weight: normal;
     padding: 14px 8px 0px 8px;
 }
 
@@ -474,6 +475,7 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     align-self: center;
     color: var(--datagrid-pagination-records-color);
     display: flex;
+    font-weight: normal;
 }
 
 .datagrid-pagination-controller {
@@ -641,6 +643,14 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
 }
 
 /****** FILTER STYLE ********/
+
+.wj-dropdown-panel .wj-control {
+    text-align: start;
+}
+
+.wj-listbox .wj-listbox-item {
+    text-align: start;
+}
 
 .wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor {
     font-size: var(--datagrid-filter-font-size);

--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -151,7 +151,6 @@
     border-bottom: var(--datagrid-cell-border-bottom);
     border-right: var(--datagrid-cell-border-right);
     color: var(--datagrid-cell-color);
-    font-weight: normal;
     padding: 14px 8px 0px 8px;
 }
 
@@ -475,7 +474,6 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     align-self: center;
     color: var(--datagrid-pagination-records-color);
     display: flex;
-    font-weight: normal;
 }
 
 .datagrid-pagination-controller {
@@ -643,14 +641,6 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
 }
 
 /****** FILTER STYLE ********/
-
-.wj-dropdown-panel .wj-control {
-    text-align: start;
-}
-
-.wj-listbox .wj-listbox-item {
-    text-align: start;
-}
 
 .wj-dropdown-panel.wj-control.wj-content.wj-columnfiltereditor {
     font-size: var(--datagrid-filter-font-size);


### PR DESCRIPTION

### What was happening
* When used inside a popup, the filter's dropdown values got misaligned, changing to a centered alignment and the Grid content and pagination got bold.

### What was done
* Added the default CSS properties to cover these use cases and apply them to RTL as well.

### Test Steps

- **Test Case 1**:
    - Go to the test page 
    - Check the Grid styles are correct as well as the pagination and the filters (by condition / by value)
    - Click on “Open Grid in Popup“
    - Check the Grid styles are correct as well as the pagination and the filters (by condition / by value)


- **Test Case 2 - RTL**:
    - Go to the test page 
    - Select `ar-AE` locale to enable RTL
    - Check the Grid styles are correct as well as the pagination and the filters (by condition / by value)
    - Click on “Open Grid in Popup“
    - Check the Grid styles are correct as well as the pagination and the filters (by condition / by value)


### Screenshots

![image](https://github.com/user-attachments/assets/891da9bc-5ccc-4a30-9922-6968b6fecc7c)



### Checklist
* [X] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems 
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

