### PR TITLE
ROU-10980: The class that should have been set for the RowClass of TextColumn is not being applied

### DIFF
--- a/src/OutSystems/GridAPI/ColumnManager.ts
+++ b/src/OutSystems/GridAPI/ColumnManager.ts
@@ -143,7 +143,12 @@ namespace OutSystems.GridAPI.ColumnManager {
 	): void {
 		Performance.SetMark('ColumnManager.changeProperty');
 
-		const grid = GetGridByColumnId(columnID);
+		const column = GetColumnById(columnID);
+		if(column === undefined){
+			throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.Column_NotFound);
+		}
+
+		const grid = column.grid;
 
 		if (grid !== undefined) {
 			grid.changeColumnProperty(columnID, propertyName, propertyValue);


### PR DESCRIPTION
This PR is to fix ConditionalFormat RowClass not being applied when there are two Grids in the screen.

### What was happening
* When using the `GetGridByColumnId` method was returning the wrong Grid object when there was two Grids in the DOM.

### What was done
* Now, we obtain the Grid object through the Colum object instead.

### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

