### PR TITLE
ROU-11327: Fix tooltip issue with Grouped Columns and increment version

### DIFF
--- a/gulp/DefaultSpecs.js
+++ b/gulp/DefaultSpecs.js
@@ -19,7 +19,7 @@ const constants = {
 
 // Store the default project specifications
 const specs = {
-	version: '2.17.0',
+	version: '2.18.0',
 	name: 'OutSystems DataGrid',
 	description: '',
 	url: 'Website:\n • ' + constants.websiteUrl,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outsystems-datagrid",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "OutSystems Data Grid for Reactive Web",
   "author": "UI Components Team",
   "license": "BSD-3-Clause",

--- a/src/OSFramework/DataGrid/Constants.ts
+++ b/src/OSFramework/DataGrid/Constants.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.DataGrid.Constants {
 	/* OutSystems Data Grid Version */
-	export const OSDataGridVersion = '2.17.0';
+	export const OSDataGridVersion = '2.18.0';
 	/* OutSystems null values */
 	export const OSNullDate = '1900-01-01';
 	export const OSNullDateTime = '1900-01-01T00:00:00';

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -33,12 +33,8 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				}
 			} else if (cellType === wijmo.grid.CellType.ColumnHeader) {
 				// If the Column Header is from a Group Column, we need to use a different approach than the regular header
-				// We can check if the current target is a ColumnGroup by checking its class and if providerIndex is -1
-				if (
-					_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup) &&
-					this._grid.getColumnByIndex(ht.getColumn().index).providerIndex === -1
-				) {
-					this._setColumnGroupHeaderTooltip(_currTarget);
+				if (_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup)) {
+					this._setColumnGroupHeaderTooltip(_currTarget, ht);
 				} else {
 					this._setHeaderTooltip(_currTarget, ht);
 				}
@@ -76,14 +72,11 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			}
 		}
 
-		private _setColumnGroupHeaderTooltip(cell: HTMLElement) {
+		private _setColumnGroupHeaderTooltip(cell: HTMLElement, htCell: wijmo.grid.HitTestInfo) {
 			// Do nothing if a tooltip is already set for this column
 			if (this._tooltip.getTooltip(cell)) return;
 			// Otherwise, the tooltip will be the header text
-			const headerTooltip = OSFramework.DataGrid.Helper.Sanitize(cell.innerText);
-
-			this._tooltipClass(false);
-			this._tooltip.show(cell, headerTooltip);
+			this._setHeaderTooltip(cell, htCell);
 		}
 
 		private _setHeaderTooltip(cell: HTMLElement, htCell: wijmo.grid.HitTestInfo) {

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -32,8 +32,12 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					this._setCellTooltip(_currTarget, ht.getColumn().binding, ht.row);
 				}
 			} else if (cellType === wijmo.grid.CellType.ColumnHeader) {
-				// If the Column Header is from a Group Column, we need to use a different approach that the regular header
-				if (_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup)) {
+				// If the Column Header is from a Group Column, we need to use a different approach than the regular header
+				// We can check if the current target is a ColumnGroup by checking its class and if providerIndex is -1
+				if (
+					_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup) &&
+					this._grid.getColumnByIndex(ht.getColumn().index).providerIndex === -1
+				) {
 					this._setColumnGroupHeaderTooltip(_currTarget);
 				} else {
 					this._setHeaderTooltip(_currTarget, ht);

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -32,15 +32,13 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					this._setCellTooltip(_currTarget, ht.getColumn().binding, ht.row);
 				}
 			} else if (cellType === wijmo.grid.CellType.ColumnHeader) {
+				const col = ht.getColumn(true) as wijmo.grid.ColumnGroup;
 				// If the Column Header is from a Group Column, we need to use a different approach than the regular header
 				// We can check if the current target is a ColumnGroup by checking its class and if it has columns or columnGroups
 				if (
 					_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup) &&
-					((ht.getColumn(true)._binding === undefined &&
-						(ht.getColumn(true) as wijmo.grid.ColumnGroup).columns !== undefined &&
-						(ht.getColumn(true) as wijmo.grid.ColumnGroup).columns.length > 0) ||
-						((ht.getColumn(true) as wijmo.grid.ColumnGroup).columnGroups !== undefined &&
-							(ht.getColumn(true) as wijmo.grid.ColumnGroup).columnGroups.length > 0))
+					((col._binding === undefined && col.columns !== undefined && col.columns.length > 0) ||
+						(col.columnGroups !== undefined && col.columnGroups.length > 0))
 				) {
 					this._setColumnGroupHeaderTooltip(_currTarget);
 				} else {

--- a/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ToolTip.ts
@@ -33,8 +33,16 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				}
 			} else if (cellType === wijmo.grid.CellType.ColumnHeader) {
 				// If the Column Header is from a Group Column, we need to use a different approach than the regular header
-				if (_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup)) {
-					this._setColumnGroupHeaderTooltip(_currTarget, ht);
+				// We can check if the current target is a ColumnGroup by checking its class and if it has columns or columnGroups
+				if (
+					_currTarget.classList.contains(Helper.Constants.CssClasses.ColumnGroup) &&
+					((ht.getColumn(true)._binding === undefined &&
+						(ht.getColumn(true) as wijmo.grid.ColumnGroup).columns !== undefined &&
+						(ht.getColumn(true) as wijmo.grid.ColumnGroup).columns.length > 0) ||
+						((ht.getColumn(true) as wijmo.grid.ColumnGroup).columnGroups !== undefined &&
+							(ht.getColumn(true) as wijmo.grid.ColumnGroup).columnGroups.length > 0))
+				) {
+					this._setColumnGroupHeaderTooltip(_currTarget);
 				} else {
 					this._setHeaderTooltip(_currTarget, ht);
 				}
@@ -72,11 +80,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			}
 		}
 
-		private _setColumnGroupHeaderTooltip(cell: HTMLElement, htCell: wijmo.grid.HitTestInfo) {
+		private _setColumnGroupHeaderTooltip(cell: HTMLElement) {
 			// Do nothing if a tooltip is already set for this column
 			if (this._tooltip.getTooltip(cell)) return;
 			// Otherwise, the tooltip will be the header text
-			this._setHeaderTooltip(cell, htCell);
+			const headerTooltip = OSFramework.DataGrid.Helper.Sanitize(cell.innerText);
+
+			this._tooltipClass(false);
+			this._tooltip.show(cell, headerTooltip);
 		}
 
 		private _setHeaderTooltip(cell: HTMLElement, htCell: wijmo.grid.HitTestInfo) {


### PR DESCRIPTION
### What was happening
* There was an issue where the column headers displayed incorrect tooltip content when using grouped columns in a Grid:


### What was done
* Improved the validation about the tooltip method to be called on the internal event handler `_onMouseEnter(e)` because if the _Column Header_ is from a _Group Column_, we need to use a different approach than the regular header.
* We can check if the current target is a _ColumnGroup_ by checking its CSS class `wj-colgroup` and, if there is no binding and the number of `columns` inside _ColumnGroup_ > 0 or if the number of `columnGroups` inside _ColumnGroup_ > 0.

### Test Steps
1. Go to a screen with two Grids, one with Grouped Columns and another without
2. On the one with Grouped Columns hover all Column Headers and check that the tooltip content is the expected
3. Repeat the same steps for the one without Grouped Columns for regression checks


### Screenshots

- **Issue**:

![ToolttipGroupHeaderIssues](https://github.com/user-attachments/assets/304597b3-1220-4650-a556-5709f1f5efe8)

- **Fixed Issue**:

![TooltipGroupedColumnsIssueFixed](https://github.com/user-attachments/assets/ab6e58d9-6c8e-4aac-a7ea-eb3866886190)


### Checklist
* [X] tested locally
* [X] documented the code
* [X] clean all warnings and errors of eslint


