### PR TITLE
ROU-4828: Fix OnCellValueChange event returning newValue = oldValue when it is triggered via SetCellData

### DIFF
--- a/src/OSFramework/DataGrid/Feature/ICellData.ts
+++ b/src/OSFramework/DataGrid/Feature/ICellData.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace OSFramework.DataGrid.Feature {
 	export interface ICellData {
+		getCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn): unknown;
 		/**
 		 * Responsible for updating a specific cell -
 		 * This is needed in a case we wnat to update another column cell, for example when a cell content is denpendent on another.

--- a/src/OSFramework/DataGrid/Feature/IValidationMark.ts
+++ b/src/OSFramework/DataGrid/Feature/IValidationMark.ts
@@ -17,7 +17,9 @@ namespace OSFramework.DataGrid.Feature {
 		validateCell(
 			rowNumber: number,
 			column: OSFramework.DataGrid.Column.IColumn,
-			triggerOnCellValueChange: boolean
+			currValue?: unknown,
+			oldValue?: unknown,
+			triggerOnCellValueChange?: boolean
 		): void;
 		validateRow(rowNumber: number): void;
 		// clearByRow(row: number): void;

--- a/src/OutSystems/GridAPI/Cell.ts
+++ b/src/OutSystems/GridAPI/Cell.ts
@@ -60,7 +60,7 @@ namespace OutSystems.GridAPI.Cells {
 		const grid = GridManager.GetGridById(gridID);
 		const column = grid.getColumn(columnID);
 		if (column === undefined) return;
-		grid.features.validationMark.validateCell(rowIndex, column, triggerOnCellValueChange);
+		grid.features.validationMark.validateCell(rowIndex, column, null, null, triggerOnCellValueChange);
 		Performance.SetMark('Cells.validateCell-end');
 		Performance.GetMeasure('@datagrid-Cells.validateCell', 'Cells.validateCell', 'Cells.validateCell-end');
 	}
@@ -124,8 +124,9 @@ namespace OutSystems.GridAPI.Cells {
 				if (showDirtyMark) {
 					grid.features.dirtyMark.saveOriginalValue(rowIndex, column.providerIndex);
 				}
+				const oldValue = grid.features.cellData.getCellData(rowIndex, column);
 				grid.features.cellData.setCellData(rowIndex, column, value);
-				grid.features.validationMark.validateCell(rowIndex, column, triggerOnCellValueChange);
+				grid.features.validationMark.validateCell(rowIndex, column, value, oldValue, triggerOnCellValueChange);
 			},
 		});
 

--- a/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
+++ b/src/Providers/DataGrid/Wijmo/Columns/DropdownColumn.ts
@@ -172,14 +172,7 @@ namespace Providers.DataGrid.Wijmo.Column {
 				// always clear the child cell when the parent changes
 				this.grid.provider.setCellData(rowNumber, this.provider.index, '', true);
 
-				this.grid.features.validationMark.validateCell(rowNumber, this, false);
-
-				this.columnEvents.trigger(
-					OSFramework.DataGrid.Event.Column.ColumnEventType.OnCellValueChange,
-					'',
-					originalValue,
-					rowNumber
-				);
+				this.grid.features.validationMark.validateCell(rowNumber, this, "", originalValue, true);
 			}
 		}
 

--- a/src/Providers/DataGrid/Wijmo/Features/CellData.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/CellData.ts
@@ -17,6 +17,10 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			//
 		}
 
+		public getCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn): unknown {
+			return this._grid.provider.getCellData(rowNumber, column.provider.index, false);
+		}
+
 		public setCellData(rowNumber: number, column: OSFramework.DataGrid.Column.IColumn, value: string): void {
 			if (column.columnType === OSFramework.DataGrid.Enum.ColumnType.DateTime) {
 				value = this._grid.dataSource.trimSecondsFromDate(value);

--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -600,17 +600,20 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		public validateCell(
 			rowNumber: number,
 			column: OSFramework.DataGrid.Column.IColumn,
-			triggerOnCellValueChange = true
+			currValue: unknown,
+			oldValue: unknown,
+			triggerOnCellValueChange: boolean
 		): void {
 			// This method gets executed by an API. No values change in columns, so the current value and the original one (old value) are the same.
-			const currValue = this._grid.provider.getCellData(rowNumber, column.provider.index, false);
+			const newValue = currValue ?? this._grid.provider.getCellData(rowNumber, column.provider.index, false);
+			const previousValue = oldValue ?? newValue;
 
 			//If we decide not to trigger the column events we will skip this step
 			if (triggerOnCellValueChange) {
 				// Triggers the events of OnCellValueChange associated to a specific column in OS
-				this._triggerEventsFromColumn(rowNumber, column.uniqueId, currValue, currValue);
+				this._triggerEventsFromColumn(rowNumber, column.uniqueId, newValue, previousValue);
 			} else {
-				this._setCellStatus(column, rowNumber, currValue);
+				this._setCellStatus(column, rowNumber, newValue);
 			}
 		}
 


### PR DESCRIPTION
This PR is for fix OnCellValueChange event returning newValue = oldValue when it is triggered via SetCellData

### What was happening
* The OnCellValueChange is triggered after using the SetCellData returns the NewValue and OldValue parameters returned are the same.
* There is a not a good reason for it unless bad implementation.
* The `validateCell` method validates the cell and triggers the OnCellValueChange event with `oldValue = newValue` when the `triggerOnCellValueChange` parameter is true. This method is used in three places:
    * In the DropdownColumn’s `_parentCellValueChangeHandler` method. The `validateCell` is called with the `triggerOnCellValueChange` equals false and then another call is done to trigger the event using the ColumnEvents' trigger method.
    * In the `ValidateCell’s` API method where the `validateCell’s` `triggerOnCellValueChange` parameter depends on what is sent to the API. For this method, it makes sense that the `oldValue = newValue`, because the cell value does not change.
    * In the `SetCellData’s` API method where, like the `ValidateCell’s` API, the `validateCell’s` `triggerOnCellValueChange` parameter depends on what is sent to the API.

### What was done
* Removed the part that triggers the OnCellValueChange event from the `_parentCellValueChangeHandler` method and use the one from the `validateCell` method 
* Add a new parameter `oldValue` to the `validateCell` method to be used in the event trigger.
* When the `oldValue` is null/undefined and `triggerOnCellValueChange = true` , then `oldValue` needs to be equal `newValue`.
* When `newValue` is null/undefined, then we use the `getCellData` method.

### Test Steps
1. 


### Screenshots
(prefer animated gif)


### Checklist
* [ ] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

