### PR TITLE
ROU-11492: Fix access to secrets

### DIFF
--- a/.github/os-git-actions/setup-gpg/action.yml
+++ b/.github/os-git-actions/setup-gpg/action.yml
@@ -1,13 +1,23 @@
 name: 'setup-gpg'
 description: 'Prepare to get following commits signed'
 
+inputs:
+    gpgPriv:
+        description: 'GPG Private key'
+        required: true
+        default: ''
+    gpgPassPhrase:
+        description: 'GPG passphrase'
+        required: false
+        default: '""'
+
 runs:
     using: composite
     steps:
         - name: Import and load GPG key
           uses: crazy-max/ghaction-import-gpg@v6
           with:
-              gpg_private_key: ${{ secrets.GPG_SIGN_KEY }}
-              passphrase: ${{ secrets.GPG_PASSPHRASE }}
+              gpg_private_key: ${{ inputs.gpgPriv }}
+              passphrase: ${{ inputs.gpgPassPhrase }}
               git_user_signingkey: true
               git_commit_gpgsign: true

--- a/.github/os-git-actions/signed-commit/action.yml
+++ b/.github/os-git-actions/signed-commit/action.yml
@@ -13,12 +13,23 @@ inputs:
         description: 'Defines if a `git add.` should be made or not.'
         required: false
         default: false
+    gpgPriv:
+        description: 'GPG Private key'
+        required: true
+        default: ''
+    gpgPassPhrase:
+        description: 'GPG passphrase'
+        required: false
+        default: '""'
 
 runs:
     using: composite
     steps:
         - name: Setup GPG to sign commits
           uses: ./.github/os-git-actions/setup-gpg/
+          with:
+              gpgPriv: ${{ inputs.gpgPriv }}
+              gpgPassPhrase: ${{ inputs.gpgPassPhrase }}
 
         - name: Perform git commit
           uses: ./.github/os-git-actions/manual-commit/

--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -119,3 +119,5 @@ jobs:
                   branch: dev
                   message: 'Updated into v${{ inputs.new-dev-release }} [skip ci]'
                   newFiles: true
+                  gpgPriv: ${{ secrets.GPG_SIGN_KEY }}
+                  gpgPassPhrase: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
This PR is for fixing the access to the github secrets.

### What was happening
* Due to a misunderstanding the place where the repo secrets were being accessed from, they were not available.

### What was done
* Created input parameters in the git actions
* The workflow accesses and passes the secrets as input values

### Impact
* These changes *only* affects the workflow used for the creation of new Pre-Releases

### Checklist
* [x] tested locally
* [ ] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)