### PR TITLE
ROU-11690: Incorrect scroll interaction of a Grid within Tabs

### DIFF
--- a/styles/Grid.css
+++ b/styles/Grid.css
@@ -463,7 +463,7 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
 }
 
 .datagrid-container {
-    height: 100%;
+    height: inherit;
     width: 100%;
     -servicestudio-height: 100% !important;
     -servicestudio-position: relative;
@@ -517,9 +517,7 @@ div[wj-part="ch"]:has(.wj-header.wj-frozen-col) {
     width: var(--datagrid-pagination-button-width);
 
     -servicestudio-background: var(--datagrid-pagination-button-background);
-    -servicestudio-border-radius: var(
-        --datagrid-pagination-button-border-radius
-    );
+    -servicestudio-border-radius: var(--datagrid-pagination-button-border-radius);
     -servicestudio-border: var(--datagrid-pagination-button-border);
     -servicestudio-height: 32px;
     -servicestudio-margin-left: var(--datagrid-pagination-button-margin-left);


### PR DESCRIPTION
### What was happening
* After undoing (Ctrl/Cmd+Z) an undoable action like a cell value update or a column sort, a forceful scroll occurred, which could hide part of the UI above the DataGrid.
* The element with CSS class `datagrid-container` had its height set to 100%, which then caused the `osui-tabs__content-item` to have a higher scroll height than `BoundingClientRect.height`. 
* This behaviour caused a scroll to happen when an action was undone and the DataGrid was focused.
* This happened when not setting a fixed height for the Grid.

### What was done
* The `datagrid-container` can be styled so that its height is set to `inherit` which should fix the issue and cause no harm for other use cases.

### Test Steps
1. Add the Tabs component to a Screen
2. Add some elements like some Buttons to the beginning of the “Content” placeholder in one of the Tabs
3. Add the OS DataGrid after the elements you added in the previous step and set it up with some data
4. In Runtime, perform some action like changing Data, adding a Row, or sorting a column
5. Press Ctrl/Cmd+Z
6. Check that nothing gets broken


### Screenshots
![ROU-11690_Issue](https://github.com/user-attachments/assets/63200d03-0a2c-452b-99e0-695062bf2237)



### Checklist
* [X] tested locally
* [ ] documented the code
* [X] clean all warnings and errors of eslint
* [X] requires changes in OutSystems 
* [X] requires new sample page in OutSystems

