### PR TITLE
ROU-11651: Triggering event with the correct oldValue

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ValidationMark.ts
@@ -607,8 +607,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 			//If we decide not to trigger the column events we will skip this step
 			if (triggerOnCellValueChange) {
+				const oldValue = this._grid.features.dirtyMark.getOldValue(rowNumber, column.config.binding);
 				// Triggers the events of OnCellValueChange associated to a specific column in OS
-				this._triggerEventsFromColumn(rowNumber, column.uniqueId, currValue, currValue);
+				this._triggerEventsFromColumn(rowNumber, column.uniqueId, oldValue, currValue);
 			} else {
 				this._setCellStatus(column, rowNumber, currValue);
 			}


### PR DESCRIPTION
This PR is for fixing the one of the values returned on the `OnCellValueChange` event, for when the the `SetCellValue` API is used to change a cell value. The value fixed, represents the previous data in cell.

### What was happening
* The event `OnCellValueChange` was returning just returning the newValue when the event was triggered through the usage of the  `SetCellData`.

### What was done
* The previous value of the cell is now obtained and returned in those circumstances.

### Test Steps
1. Click on a button that sets the value of a cell
2. Make sure that the API is using `TriggerChangeEvent` = `true`
3. See the event sent out by the respective column, has the old and the new value

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

