### PR TITLE
ROU-11492: Using GPG secret temporarely

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
     build:
-        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/ts-build-project.yaml@820fa8e6ffa0c0cb3ea09434b01eec8da6da37b5 # v0.2.3-alpha
+        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/ts-build-project.yaml@c2c2fe8d5389eadb5590af71c42fbc898dda8360 #v0.2.4-alpha
         with:
             github-ref: ${{ github.ref }}
             run-jest-tests: false

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -22,8 +22,10 @@ permissions:
 
 jobs:
     create-release-candidate:
-        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/pre-release.yaml@820fa8e6ffa0c0cb3ea09434b01eec8da6da37b5 # v0.2.3-alpha
+        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/pre-release.yaml@c2c2fe8d5389eadb5590af71c42fbc898dda8360 #v0.2.4-alpha
         with:
             new-version: ${{ inputs.new-version }}
             release-date: ${{ inputs.release-date }}
             new-dev-release: ${{ inputs.new-dev-release }}
+        secrets:
+            GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGN_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
     set-release-latest:
-        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/release.yaml@820fa8e6ffa0c0cb3ea09434b01eec8da6da37b5 # v0.2.3-alpha
+        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/release.yaml@c2c2fe8d5389eadb5590af71c42fbc898dda8360 #v0.2.4-alpha
         with:
             new-version: ${{ inputs.new-version }}
             update-prerelease-into-latest: ${{ inputs.update-prerelease-into-latest }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ on:
 
 permissions:
     id-token: write
-    contents: read
+    contents: write
 
 jobs:
     set-release-latest:


### PR DESCRIPTION
This PR is for updating how the pre-release workflow is invoked.