### PR TITLE
ROU-11492: adding synchronize PR event 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on:
     # Triggers the workflow on push events but only for the "dev" branch.
     pull_request:
         branches: ['dev']
-        types: [opened, reopened]
+        types: [opened, reopened, synchronize]
 
 concurrency:
     group: ${{ github.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
     build:
-        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/ts-build-project.yaml@c2c2fe8d5389eadb5590af71c42fbc898dda8360 #v0.2.4-alpha
+        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/ts-build-project.yaml@7ffd7f90f6e5016bd92d0e050d2516084b99c2f6 #v0.2.5
         with:
             github-ref: ${{ github.ref }}
             run-jest-tests: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: PullRequest into Dev branch
+name: PullRequest into Dev
 on:
     # Triggers the workflow on push events but only for the "dev" branch.
     pull_request:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
     create-release-candidate:
-        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/pre-release.yaml@c2c2fe8d5389eadb5590af71c42fbc898dda8360 #v0.2.4-alpha
+        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/pre-release.yaml@7ffd7f90f6e5016bd92d0e050d2516084b99c2f6 #v0.2.5
         with:
             new-version: ${{ inputs.new-version }}
             release-date: ${{ inputs.release-date }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
     set-release-latest:
-        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/release.yaml@c2c2fe8d5389eadb5590af71c42fbc898dda8360 #v0.2.4-alpha
+        uses: OutSystems/ui-components.github-reusable-workflows/.github/workflows/release.yaml@7ffd7f90f6e5016bd92d0e050d2516084b99c2f6 #v0.2.5
         with:
             new-version: ${{ inputs.new-version }}
             update-prerelease-into-latest: ${{ inputs.update-prerelease-into-latest }}


### PR DESCRIPTION
Adding event `synchronize` so that the PR related workflows, run every time the PR is open, reopen, or new commits added to it.