### PR TITLE
ROU-12064: Pasting into Grid cell followed by Right-Click copy marks cell as unedited

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/ContextMenu.ts
@@ -262,9 +262,18 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		 */
 		private _raiseClickEvent(menuItemId: string): void {
 			const menuItem = this._menuItems.get(menuItemId);
+			const provider = this.grid.provider;
+			const sel = provider.selection;
+			const cell = provider.cells.getCellElement(sel.row, sel.col);
+
 			if (menuItem && menuItem.clickEvent) {
 				//RUG: the platform requires to receive the input parameters inline
 				menuItem.clickEvent(this._grid.uniqueId, this._grid);
+			}
+
+			// Restore focus to active grid cell
+			if (cell) {
+				cell.focus();
 			}
 		}
 


### PR DESCRIPTION
This PR is for fix issue when a cell is copied using the Context Menu after being edited.

### What was happening
* When a cell was edited and then copied using the Context Menu, the change was not being tracked when running the Get Changed Lines.

### What was done
* Now we set the focus to the active cell after finishing the Context Menu action.
    * This is is similar what is implemented in [this Wijmo example](https://developer.mescius.com/wijmo/demos/Grid/ContextMenus/purejs).
![image](https://github.com/user-attachments/assets/c3014148-a619-46fc-8a9c-2d95f5eefe23)
    * Despite in the example the Grid is refreshed, this was not suitable for other use cases. For example, when adding a new row via Context Menu, the dirty marks were not appearing because the Grid has been refreshed.

### Test Steps
1. Go to a test page.
2. Edit a cell.
3. In the same cell, right click to open the Context Menu.
4. Click "Copy".
5. Run the Get Changed Lines Action.
6. Check that the change was tracked correctly.


### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

