### PR TITLE
ROU-12056: Adding fix for when SavedByKey is used

### DIFF
--- a/src/Providers/DataGrid/Wijmo/Grid/FlexGrid.ts
+++ b/src/Providers/DataGrid/Wijmo/Grid/FlexGrid.ts
@@ -62,6 +62,9 @@ namespace Providers.DataGrid.Wijmo.Grid {
 				this._provider.itemsSource.itemsEdited.remove(row.dataItem);
 				this._provider.itemsSource.itemsRemoved.remove(row.dataItem);
 				this._provider.itemsSource.itemsAdded.remove(row.dataItem);
+				// RUG: Workaround provided by Mescius, July 2025
+				// Fixes the issue described in ROU-12063.
+				this._provider.itemsSource._orgVals?.delete(row.dataItem);
 			});
 		}
 


### PR DESCRIPTION
This PR is for fixing an issue that caused the Grid to return dirty lines, when in reality there weren't.

### What was happening
* When the API  `MarkChangesAsSavedByKey` was used for a given line, and a subsequent change was made in the same line and then rollback (ctrl+z), the grid would return the information that there line was changed, even though it shouldn't. 

### What was done
* With a workaround provided by Mescius, we are now clearing another `map` where the values are kept, fixing this way the issue.

### Test Steps
1. Change value of cell with text "test 1" to "edit 1"
2. Hit the button "enter"
3. Click on button "Clear all changes"
4. Notice the "Edited Items" grid contains the line that was changed
5. Click on the button "Clear first change"
6. Notice the "Edited Items" grid is now empty
7. Change value of cell with text "test 3" to "edit 2"
8. Hit the button "enter"
9. Notice the "Edited Items" grid contains the line that was changed
10. Click on the button "ctrl+z"
11. Notice the "Edited Items" grid that should be empty


### Screenshots
With the fix:
![ROU-12063](https://github.com/user-attachments/assets/e7ffc7af-f5a2-4d6f-bb42-152f03c2dae0)


### Checklist
* [x] tested locally
* [x] documented the code
* [ ] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)



[ROU-12063]: https://outsystemsrd.atlassian.net/browse/ROU-12063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ