### PR TITLE
ROU-12056: Fixing an issue that caused lines to be removed

### DIFF
--- a/src/OSFramework/DataGrid/Feature/IRows.ts
+++ b/src/OSFramework/DataGrid/Feature/IRows.ts
@@ -20,7 +20,7 @@ namespace OSFramework.DataGrid.Feature {
 		/**
 		 * Get data from a specific row.
 		 */
-		getRowData(rowNumber: number): string;
+		getRowData(rowNumber: number): unknown;
 		/**
 		 * Clear all classes from a specific row.
 		 */

--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -18,9 +18,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 				collectionView.itemsAdded.push(...chunk)
 			);
 		}
-		// eslint-disable-next-line
-		public applyState(state: any): void {
-			const collectionView = this._target.itemsSource;
+
+		public applyState(state: { action?: string; datasourceIdx?: number; items?: unknown[] }): void {
+			const collectionView = this._target.itemsSource as wijmo.collections.CollectionView;
 			if (collectionView) {
 				if (state.action === 'remove') {
 					//undo
@@ -337,8 +337,14 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			) as OSFramework.DataGrid.Feature.Auxiliar.RowStyleInfo;
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		public getRowData(rowNumber: number): any {
+		/**
+		 * Gets the data from a specific row.
+		 *
+		 * @param {number} rowNumber
+		 * @return {*}  {unknown}
+		 * @memberof Rows
+		 */
+		public getRowData(rowNumber: number): unknown {
 			const row = this._getDataItemFromRow(rowNumber);
 
 			if (!row) {

--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -32,7 +32,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 					// which is 9.
 					const startingIndex = collectionView.itemsAdded.length - state.items.length;
 
-					collectionView.itemsAdded.splice(startingIndex, state.items.length);
+					collectionView.trackChanges && collectionView.itemsAdded.splice(startingIndex, state.items.length);
 				} else {
 					//redo
 					collectionView.sourceCollection.splice(state.datasourceIdx, 0, ...state.items);

--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 namespace Providers.DataGrid.Wijmo.Feature {
 	export class GridInsertRowAction extends wijmo.undo.UndoableAction {
-		private _grid: Grid.IGridWijmo;
+		private readonly _grid: Grid.IGridWijmo;
 
 		constructor(
 			grid: Grid.IGridWijmo,
@@ -57,7 +57,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 	}
 
 	export class GridRemoveRowAction extends wijmo.undo.UndoableAction {
-		private _grid: Grid.IGridWijmo;
+		private readonly _grid: Grid.IGridWijmo;
 
 		constructor(
 			grid: Grid.IGridWijmo,
@@ -117,7 +117,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 
 				if (this._grid.gridEvents.hasHandlers(OSFramework.DataGrid.Event.Grid.GridEventType.OnDataChange)) {
 					const dataChanges = new OSFramework.DataGrid.OSStructure.DataChanges();
-					dataChanges.changedRows = state.items || state.map((state) => state.item);
+					dataChanges.changedRows = state.items ?? state.map((state) => state.item);
 					dataChanges.totalRows = this._grid.features.pagination.rowTotal;
 					this._grid.gridEvents.trigger(
 						OSFramework.DataGrid.Event.Grid.GridEventType.OnDataChange,
@@ -130,12 +130,12 @@ namespace Providers.DataGrid.Wijmo.Feature {
 	}
 
 	export class Rows implements OSFramework.DataGrid.Interface.IBuilder, OSFramework.DataGrid.Feature.IRows {
-		private _grid: Grid.IGridWijmo;
+		private readonly _grid: Grid.IGridWijmo;
 
 		/** This is going to be used as a label for the css classes saved on the metadata of the Row */
 		private readonly _internalLabel = OSFramework.DataGrid.Enum.RowMetadata.RowCss;
 
-		private _metadata: OSFramework.DataGrid.Interface.IRowMetadata;
+		private readonly _metadata: OSFramework.DataGrid.Interface.IRowMetadata;
 
 		constructor(grid: Grid.IGridWijmo) {
 			this._grid = grid;
@@ -143,10 +143,10 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		}
 
 		/**
-		 * Check if it is possible to add rows to the grid.
-		 * @returns Boolean indicating if it is possible to add rows to the grid.
+		 * Getter that checks if it is possible to add or remove rows from the grid.
+		 * This is true when the grid is not sorted, grouped or filtered.
 		 */
-		private _canAddRows(): boolean {
+		private get _canAddRemoveRows(): boolean {
 			return (
 				!this._grid.features.sort.isGridSorted &&
 				!this._grid.features.groupPanel.isGridGrouped &&
@@ -155,15 +155,19 @@ namespace Providers.DataGrid.Wijmo.Feature {
 		}
 
 		/**
+		 * Check if it is possible to add/remove rows to the grid.
+		 * @returns Boolean indicating if it is possible to add rows to the grid.
+		 */
+		private _canAddRows(): boolean {
+			return this._canAddRemoveRows;
+		}
+
+		/**
 		 * Check if it is possible to remove rows from the grid.
 		 * @returns Boolean indicating if it is possible to remove rows from the grid.
 		 */
 		private _canRemoveRows(): boolean {
-			return (
-				!this._grid.features.sort.isGridSorted &&
-				!this._grid.features.groupPanel.isGridGrouped &&
-				!this._grid.features.filter.isGridFiltered
-			);
+			return this._canAddRemoveRows;
 		}
 
 		/**

--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -70,17 +70,29 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			this._newState = undoableItems;
 		}
 
-		private _addItemToCollectionView(collectionView, item) {
-			if (collectionView.itemsRemoved.indexOf(item.item) === -1) {
-				collectionView.sourceCollection.splice(item.datasourceIdx, 1);
-				collectionView.trackChanges && collectionView.itemsRemoved.push(item.item);
+		/** Method to redo the operation */
+		private _addItemToCollectionView(
+			collectionView: wijmo.collections.CollectionView,
+			item: { datasourceIdx: number; item: unknown }
+		) {
+			// Let's remove the item from the collectionView, as it was added before.
+			collectionView.sourceCollection.splice(item.datasourceIdx, 1);
+			if (collectionView.trackChanges && collectionView.itemsRemoved.indexOf(item.item) === -1) {
+				collectionView.itemsRemoved.push(item.item);
 			}
 		}
 
-		private _removeItemFromCollectionView(collectionView, item) {
-			if (collectionView.itemsRemoved.indexOf(item.item) > -1) {
-				collectionView.sourceCollection.splice(item.datasourceIdx, 0, item.item);
-				collectionView.trackChanges && collectionView.itemsRemoved.remove(item.item);
+		/** Method to undo the operation */
+		private _removeItemFromCollectionView(
+			collectionView: wijmo.collections.CollectionView,
+			item: { datasourceIdx: number; item: unknown }
+		) {
+			// Let's add the item back to the collectionView, as it was removed before.
+			collectionView.sourceCollection.splice(item.datasourceIdx, 0, item.item);
+			// If the row existed before, we need to remove it from the itemsRemoved list.
+			// When the row is added and then removed, it does not go to the itemsRemoved list.
+			if (collectionView.trackChanges && collectionView.itemsRemoved.indexOf(item.item) > -1) {
+				collectionView.itemsRemoved.remove(item.item);
 			}
 		}
 		// eslint-disable-next-line

--- a/src/Providers/DataGrid/Wijmo/Features/Rows.ts
+++ b/src/Providers/DataGrid/Wijmo/Features/Rows.ts
@@ -100,6 +100,7 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			const collectionView = this._target.itemsSource;
 			if (collectionView) {
 				if (state.action === 'insert') {
+					//undo
 					state.items
 						.sort((a, b) => a.datasourceIdx - b.datasourceIdx)
 						.forEach((item) => {
@@ -181,6 +182,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			}
 		}
 
+		/**
+		 * Get the data item from a specific row.
+		 */
 		private _getDataItemFromRow(rowNumber: number) {
 			return this._grid.isSingleEntity
 				? OSFramework.DataGrid.Helper.Flatten(this._grid.provider.rows[rowNumber]?.dataItem)
@@ -207,6 +211,9 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			return topRow === Infinity ? 0 : topRow;
 		}
 
+		/**
+		 * Validates if it is possible to add new rows to the grid.
+		 */
 		private _validateAddNewRow(rowsAmount: number, topRowIndex: number): void {
 			if (!this._canAddRows()) {
 				throw new Error(OSFramework.DataGrid.Enum.ErrorMessages.AddRowWithActiveFilterOrSort);
@@ -308,11 +315,20 @@ namespace Providers.DataGrid.Wijmo.Feature {
 			return addedRowsNumber;
 		}
 
+		/**
+		 * Builds the rows feature.
+		 *
+		 * @memberof Rows
+		 */
 		public build(): void {
 			this._grid.provider.formatItem.addHandler(this._formatItems.bind(this));
 		}
 
-		/** Clears all the cssClass metadata associated to the rows */
+		/**
+		 * Clears all the cssClass metadata associated to the rows.
+		 *
+		 * @memberof Rows
+		 */
 		public clear(): void {
 			this._metadata.clearProperty(this._internalLabel);
 			this._grid.provider.invalidate(); //Mark to be refreshed

--- a/src/Providers/DataGrid/Wijmo/Grid/FlexGrid.ts
+++ b/src/Providers/DataGrid/Wijmo/Grid/FlexGrid.ts
@@ -65,8 +65,7 @@ namespace Providers.DataGrid.Wijmo.Grid {
 			});
 		}
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		private _getProviderConfig(): any {
+		private _getProviderConfig(): unknown {
 			if (this.hasColumnsDefined()) {
 				this.config.autoGenerateColumns = false;
 			}
@@ -267,7 +266,6 @@ namespace Providers.DataGrid.Wijmo.Grid {
 		}
 
 		public getChangesMade(): OSFramework.DataGrid.OSStructure.GridChanges {
-			// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
 			const changes = this.dataSource.getChanges(OSFramework.DataGrid.OSStructure.GridChanges);
 
 			if (this._features.validationMark.invalidRows.size > 0) {


### PR DESCRIPTION
This PR is for fixing an issue, that when using undo (ctrl+z) caused lines to be removed.

### What was happening
* When adding lines and subsequently removing the added lines, followed by undo (ctrl+z), cause the records to be inadvertently deleted.
* The cause was that, when undoing, undoing the remove lines, was **not** adding back the lines (because they didn't exist in the map `.itemsRemoved`), while undoing the add lines (removing those lines), was still running, causing extra lines to be removed.

### What was done
* Made sure that the undo of the remove lines, adds the lines back.

### Test Steps
1. Add 2 lines (click on 1 - Add Row)
2. Number of rows goes up by 2
3. Remove those 2 lines (click on 2 - Remove Row)
4. Number of rows goes back to the original value
5. Refresh the data source (click on 3 - Search)
6. The expected number of rows is the same as in the beginning


### Screenshots
![ROU-12056](https://github.com/user-attachments/assets/a3a89493-36b6-43a6-873f-4c54cb7de45f)

### Checklist
* [x] tested locally
* [x] documented the code
* [x] clean all warnings and errors of eslint
* [ ] requires changes in OutSystems (if so, provide a module with changes)
* [ ] requires new sample page in OutSystems (if so, provide a module with changes)

